### PR TITLE
Add support for sending JSON data

### DIFF
--- a/gnmi_set/gnmi_set.go
+++ b/gnmi_set/gnmi_set.go
@@ -53,6 +53,7 @@ var (
 	targetAddr = flag.String("target_addr", "localhost:10161", "The target address in the format of host:port")
 	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
+	forceJSON  = flag.Bool("force_json", false, "Interprete values as JSON")
 )
 
 func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
@@ -77,6 +78,12 @@ func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
 			pbVal = &pb.TypedValue{
 				Value: &pb.TypedValue_JsonIetfVal{
 					JsonIetfVal: jsonConfig,
+				},
+			}
+		} else if *forceJSON {
+			pbVal = &pb.TypedValue{
+				Value: &pb.TypedValue_JsonVal{
+					JsonVal: []byte(pathValuePair[1]),
 				},
 			}
 		} else {

--- a/gnmi_set/gnmi_set.go
+++ b/gnmi_set/gnmi_set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -88,9 +89,13 @@ func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
 				},
 			}
 		} else if isJSON(pathValuePair[1]) {
+			j := []byte(stripQuotes(pathValuePair[1]))
+			if !json.Valid(j) {
+				log.Exitf("Invalid JSON value:\n%s", j)
+			}
 			pbVal = &pb.TypedValue{
 				Value: &pb.TypedValue_JsonVal{
-					JsonVal: []byte(stripQuotes(pathValuePair[1])),
+					JsonVal: j,
 				},
 			}
 		} else {

--- a/gnmi_set/gnmi_set.go
+++ b/gnmi_set/gnmi_set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -24,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -32,6 +32,7 @@ import (
 	"github.com/google/gnxi/utils/credentials"
 	"github.com/google/gnxi/utils/xpath"
 
+	log "github.com/golang/glog"
 	pb "github.com/openconfig/gnmi/proto/gnmi"
 )
 
@@ -53,7 +54,8 @@ var (
 	targetAddr = flag.String("target_addr", "localhost:10161", "The target address in the format of host:port")
 	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
-	forceJSON  = flag.Bool("force_json", false, "Interprete values as JSON")
+	forceJSON  = flag.Bool("force_json", false, "Force Interprete values as JsonVal - TypedValue #10")
+	forceAny   = flag.Bool("force_any", false, "Force Interprete values as AnyVal - TypeValue #8")
 )
 
 func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
@@ -81,9 +83,13 @@ func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
 				},
 			}
 		} else if *forceJSON {
+			json, err := json.Marshal(pathValuePair[1])
+			if err != nil {
+				log.Exit(err)
+			}
 			pbVal = &pb.TypedValue{
 				Value: &pb.TypedValue_JsonVal{
-					JsonVal: []byte(pathValuePair[1]),
+					JsonVal: json,
 				},
 			}
 		} else {


### PR DESCRIPTION
This update largely supported gnmi_set to Nokia.  Beta software is still storing paths in "elememt" format and they accept JSON data only.