### PR TITLE
Fix readmes and openflow.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-Install __go__ in your system https://golang.org/doc/install.
+Install __go__ in your system https://golang.org/doc/install. Requires golang1.7+.
 
 ### Clone
 

--- a/gnmi_target/README.md
+++ b/gnmi_target/README.md
@@ -14,7 +14,7 @@ go install github.com/google/gnxi/gnmi_target
 ```
 gnmi_target \
   -bind_address :10161 \
-  -config openconfig-openflow.json
+  -config openconfig-openflow.json \
   -key server.key \
   -cert server.crt \
   -ca ca.crt \

--- a/gnmi_target/openconfig-openflow.json
+++ b/gnmi_target/openconfig-openflow.json
@@ -62,6 +62,14 @@
                     "priority": 1,
                     "source-interface": "admin",
                     "transport": "TLS"
+                  },
+                  "state": {
+                    "address": "192.0.2.10",
+                    "aux-id": 0,
+                    "port": 6633,
+                    "priority": 1,
+                    "source-interface": "admin",
+                    "transport": "TLS"
                   }
                 }
               ]


### PR DESCRIPTION
(M) gnmi_target/README.md
-fix the run example (add missing ''\")

(M) README.md
-update main README to include go version requirement.

(M) gnmi_target/openconfig-openflow.json
-Update JSON to include a "state" container. (gnmi_get example fails without this). If this is not appropriate, alternative would be change the gnmi_get
 example to use a path of: "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]" (eg leave off the '/state/address')