### PR TITLE
 send provided client certs always to server

### DIFF
--- a/utils/credentials/credentials.go
+++ b/utils/credentials/credentials.go
@@ -98,6 +98,9 @@ func ClientCredentials(server string) []grpc.DialOption {
 		tlsConfig := &tls.Config{}
 		if *insecure {
 			tlsConfig.InsecureSkipVerify = true
+			certificates, certPool := LoadCertificates()
+			tlsConfig.Certificates = certificates
+			tlsConfig.RootCAs = certPool
 		} else {
 			certificates, certPool := LoadCertificates()
 			tlsConfig.ServerName = server


### PR DESCRIPTION
In my opinion insecure means don't validate server name in certificate.
But we have to provide the certificates to the server.
