### PR TITLE
Update cert.proto

### DIFF
--- a/gnoi/cert/client.go
+++ b/gnoi/cert/client.go
@@ -101,8 +101,7 @@ func (c *Client) Rotate(ctx context.Context, certID string, params pkix.Name, si
 					Type:        pb.CertificateType_CT_X509,
 					Certificate: certPEM,
 				},
-				KeyPair:       nil,
-				CaCertificate: caCertificates,
+				CaCertificates: caCertificates,
 			},
 		},
 	}); err != nil {
@@ -195,8 +194,7 @@ func (c *Client) Install(ctx context.Context, certID string, params pkix.Name, s
 					Type:        pb.CertificateType_CT_X509,
 					Certificate: certPEM,
 				},
-				KeyPair:       nil,
-				CaCertificate: caCertificates,
+				CaCertificates: caCertificates,
 			},
 		},
 	}); err != nil {

--- a/gnoi/cert/pb/cert.pb.go
+++ b/gnoi/cert/pb/cert.pb.go
@@ -978,8 +978,11 @@ type LoadCertificateRequest struct {
 	// Certificate Id of the above certificate. This is to be provided only when
 	// there is an externally generated key pair.
 	CertificateId string `protobuf:"bytes,3,opt,name=certificate_id,json=certificateId,proto3" json:"certificate_id,omitempty"`
-	// Optional pool of CA certificates to be used for authenticating the client.
-	CaCertificate        []*Certificate `protobuf:"bytes,4,rep,name=ca_certificate,json=caCertificate,proto3" json:"ca_certificate,omitempty"`
+	// Optional bundle of CA certificates. When not empty, the provided
+  // certificates should squash the existing bundle. This field provides a
+  // simplified means to provision a CA bundle that can be used to validate
+  // other peer's certificates.
+	CaCertificates       []*Certificate `protobuf:"bytes,4,rep,name=ca_certificates,json=caCertificate,proto3" json:"ca_certificates,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
 	XXX_unrecognized     []byte         `json:"-"`
 	XXX_sizecache        int32          `json:"-"`
@@ -1030,9 +1033,9 @@ func (m *LoadCertificateRequest) GetCertificateId() string {
 	return ""
 }
 
-func (m *LoadCertificateRequest) GetCaCertificate() []*Certificate {
+func (m *LoadCertificateRequest) GetCaCertificates() []*Certificate {
 	if m != nil {
-		return m.CaCertificate
+		return m.CaCertificates
 	}
 	return nil
 }

--- a/gnoi/cert/pb/cert.proto
+++ b/gnoi/cert/pb/cert.proto
@@ -270,8 +270,11 @@ message LoadCertificateRequest {
   // there is an externally generated key pair.
   string certificate_id = 3;
 
-  // Optional pool of CA certificates to be used for authenticating the client.
-  repeated Certificate ca_certificate = 4;
+  // Optional bundle of CA certificates. When not empty, the provided
+  // certificates should squash the existing bundle. This field provides a
+  // simplified means to provision a CA bundle that can be used to validate
+  // other peer's certificates.
+  repeated Certificate ca_certificates = 4;
 }
 
 // Response from target after Loading a Certificate.

--- a/gnoi/cert/server.go
+++ b/gnoi/cert/server.go
@@ -70,6 +70,8 @@ func (s *Server) Install(stream pb.CertificateManagement_InstallServer) error {
 		return rerr
 	}
 
+	certID := genCSRRequest.CertificateId
+
 	if genCSRRequest.CsrParams.Type != pb.CertificateType_CT_X509 {
 		return fmt.Errorf("certificate type %q not supported", genCSRRequest.CsrParams.Type)
 	}
@@ -121,10 +123,9 @@ func (s *Server) Install(stream pb.CertificateManagement_InstallServer) error {
 		return rerr
 	}
 
-	certID := loadCertificateRequest.CertificateId
 	pemCert := loadCertificateRequest.Certificate.Certificate
 	pemCACerts := [][]byte{}
-	for _, cert := range loadCertificateRequest.CaCertificate {
+	for _, cert := range loadCertificateRequest.CaCertificates {
 		if cert.Type != pb.CertificateType_CT_X509 {
 			rerr := fmt.Errorf("unexpected Certificate type: %d", cert.Type)
 			log.Error(rerr)
@@ -171,6 +172,8 @@ func (s *Server) Rotate(stream pb.CertificateManagement_RotateServer) error {
 		log.Error(rerr)
 		return rerr
 	}
+
+	certID := genCSRRequest.CertificateId
 
 	if genCSRRequest.CsrParams.Type != pb.CertificateType_CT_X509 {
 		return fmt.Errorf("certificate type %q not supported", genCSRRequest.CsrParams.Type)
@@ -223,10 +226,9 @@ func (s *Server) Rotate(stream pb.CertificateManagement_RotateServer) error {
 		return rerr
 	}
 
-	certID := loadCertificateRequest.CertificateId
 	pemCert := loadCertificateRequest.Certificate.Certificate
 	pemCACerts := [][]byte{}
-	for _, cert := range loadCertificateRequest.CaCertificate {
+	for _, cert := range loadCertificateRequest.CaCertificates {
 		if cert.Type != pb.CertificateType_CT_X509 {
 			rerr := fmt.Errorf("unexpected Certificate type: %d", cert.Type)
 			log.Error(rerr)


### PR DESCRIPTION
1) Update cert.proto such that ca_certificate is named ca_certificates as in the gNOI OpenConfig repo.
2) Fix server to accept CertificateID on GenerateCSR instead of LoadCertificate.