### PR TITLE
Removing pathlen information in accordance with RFC5280 4.2.1.9

### DIFF
--- a/utils/entity/entity.go
+++ b/utils/entity/entity.go
@@ -240,8 +240,6 @@ func Template(cn string) *x509.Certificate {
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		// IsCA,
 		KeyUsage:       x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		MaxPathLen:     certMaxPathLen,
-		MaxPathLenZero: true,
 		NotAfter:       time.Now().Add(24 * 365 * time.Hour),
 		NotBefore:      time.Now(),
 		// PermittedDNSDomains,

--- a/utils/entity/entity.go
+++ b/utils/entity/entity.go
@@ -102,8 +102,6 @@ func FromSigningRequest(csr *x509.CertificateRequest) (*Entity, error) {
 		DNSNames:              csr.DNSNames,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		MaxPathLen:            certMaxPathLen,
-		MaxPathLenZero:        true,
 		NotAfter:              time.Now().Add(certExpiration),
 		NotBefore:             time.Now(),
 		SignatureAlgorithm:    csr.SignatureAlgorithm,

--- a/utils/entity/entity.go
+++ b/utils/entity/entity.go
@@ -34,7 +34,6 @@ var (
 	bigInt         = big.NewInt(0).Lsh(big.NewInt(1), 128)
 	rsaBitSize     = 2048
 	randReader     = rand.Reader
-	certMaxPathLen = 5
 	certExpiration = (365 * 24 * time.Hour)
 )
 

--- a/utils/entity/entity.go
+++ b/utils/entity/entity.go
@@ -34,6 +34,7 @@ var (
 	bigInt         = big.NewInt(0).Lsh(big.NewInt(1), 128)
 	rsaBitSize     = 2048
 	randReader     = rand.Reader
+	certMaxPathLen = 5
 	certExpiration = (365 * 24 * time.Hour)
 )
 
@@ -213,6 +214,8 @@ func TemplateCA(cn string) *x509.Certificate {
 	ca := Template(cn)
 	ca.KeyUsage = x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign
 	ca.IsCA = true
+	ca.MaxPathLen = certMaxPathLen
+	ca.MaxPathLenZero = true
 	return ca
 }
 


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc5280 the pathlen information must be omitted if the CA boolean is false. In this case, since you never assert the CA to be true (hence default false) you must remove the pathlen information.