### PR TITLE
Allow revoke to receive multiple cert ids

### DIFF
--- a/gnoi_cert/gnoi_cert.go
+++ b/gnoi_cert/gnoi_cert.go
@@ -187,13 +187,12 @@ func rotate() {
 
 // revoke revokes a certificate in authenticated mode.
 func revoke() {
-	
-    var certNames = []string { *certID }
+    	var revokeCertIDs  = []string { *certID }
     
     	if *certIDs != "" {
-        	certNames = strings.FieldsFunc(*certIDs, func(r rune) bool { return r == ',' })
-        	if len(certNames) == 0 {
-            		log.Exit("Cannot specify empty certificate ID using -cert_ids")
+        	revokeCertIDs  = strings.FieldsFunc(*certIDs, func(r rune) bool { return r == ',' })
+        	if len(revokeCertIDs ) == 0 {
+            		log.Exit("Must specify comma separated certificate IDs when using -cert_ids")
         	}
     	} else if *certID == "" {
                log.Exit("Must set a certificate ID with -cert_id or set multiple IDs with -cert_ids")
@@ -201,7 +200,7 @@ func revoke() {
 	conn, client := gnoiAuthenticated(*targetCN)
 	defer conn.Close()
 
-	revoked, err := client.RevokeCertificates(ctx, certNames)
+	revoked, err := client.RevokeCertificates(ctx, revokeCertIDs )
 	if err != nil {
 		log.Exit("Failed RevokeCertificates:", err)
 	}

--- a/gnoi_cert/gnoi_cert.go
+++ b/gnoi_cert/gnoi_cert.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	certID     = flag.String("cert_id", "", "Certificate Management certificate ID.")
-	certID_list = flag.String("cert_ids", "", "Comma seperated list of Certificate Management certificate IDs for revoke operation")
+	certID_list = flag.String("cert_ids", "", "Comma separated list of Certificate Management certificate IDs for revoke operation")
 	op         = flag.String("op", "get", "Certificate Management operation, one of: provision, install, rotate, get, revoke, check")
 	ca         = flag.String("ca", "", "CA certificate file.")
 	key        = flag.String("key", "", "Private key file.")

--- a/gnoi_cert/gnoi_cert.go
+++ b/gnoi_cert/gnoi_cert.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	certID     = flag.String("cert_id", "", "Certificate Management certificate ID.")
-	certID_list = flag.String("cert_ids", "", "Comma separated list of Certificate Management certificate IDs for revoke operation")
+	certIDs    = flag.String("cert_ids", "", "Comma separated list of Certificate Management certificate IDs for revoke operation")
 	op         = flag.String("op", "get", "Certificate Management operation, one of: provision, install, rotate, get, revoke, check")
 	ca         = flag.String("ca", "", "CA certificate file.")
 	key        = flag.String("key", "", "Private key file.")
@@ -188,11 +188,11 @@ func rotate() {
 // revoke revokes a certificate in authenticated mode.
 func revoke() {
 	
-    var cert_name_list = []string { *certID }
+    var certNames = []string { *certID }
     
-    	if *certID_list != "" {
-        	cert_name_list = strings.FieldsFunc(*certID_list, func(r rune) bool { return r == ',' })
-        	if len(cert_name_list) == 0 {
+    	if *certIDs != "" {
+        	certNames = strings.FieldsFunc(*certIDs, func(r rune) bool { return r == ',' })
+        	if len(certNames) == 0 {
             		log.Exit("Cannot specify empty certificate ID using -cert_ids")
         	}
     	} else if *certID == "" {
@@ -201,7 +201,7 @@ func revoke() {
 	conn, client := gnoiAuthenticated(*targetCN)
 	defer conn.Close()
 
-	revoked, err := client.RevokeCertificates(ctx, cert_name_list)
+	revoked, err := client.RevokeCertificates(ctx, certNames)
 	if err != nil {
 		log.Exit("Failed RevokeCertificates:", err)
 	}


### PR DESCRIPTION
The revoke rpc supports using multiple certificate IDs. This change is to add another argument, `-cert_ids`, that allows a comma separated list of certificate IDs to be passed. The argument is only used by revoke and ignored by other rpcs. The behaviour of `-cert_id` remains unchanged.

Usage:
```
$ alias gnoi_cert
alias gnoi_cert='./gnoi_cert -ca alishar.crt -key alishar.key -target_name gnoi_target -logtostderr'

$ gnoi_cert -op revoke -cert_ids c1,c2,c4
I1009 10:18:36.955688   58961 gnoi_cert.go:210] RevokeCertificates:
{c1: "does not exist",
 c4: "does not exist"}
```

Closes https://github.com/google/gnxi/issues/85