### PR TITLE
Fixed type error, ResetTarget returns a *ResetError

### DIFF
--- a/gnoi/reset/client.go
+++ b/gnoi/reset/client.go
@@ -44,13 +44,13 @@ func NewClient(c *grpc.ClientConn) *Client {
 }
 
 // ResetTarget invokes gRPC start service on the server.
-func (c *Client) ResetTarget(ctx context.Context, zeroFill, rollbackOS bool) error {
+func (c *Client) ResetTarget(ctx context.Context, zeroFill, rollbackOS bool) *ResetError {
 	out, err := c.client.Start(ctx, &pb.StartRequest{
 		FactoryOs: rollbackOS,
 		ZeroFill:  zeroFill,
 	})
 	if err != nil {
-		return err
+		return &ResetError{Msgs: []string{err.Error()}}
 	}
 	return CheckResponse(out)
 }

--- a/gnoi_reset/gnoi_reset.go
+++ b/gnoi_reset/gnoi_reset.go
@@ -58,7 +58,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), *timeOut)
 	defer cancel()
 
-	if err = client.ResetTarget(ctx, *rollbackOs, *zeroFill); err != nil {
+	if err := client.ResetTarget(ctx, *rollbackOs, *zeroFill); err != nil {
 		log.Errorf("Error Resetting Target: %v", err)
 	} else {
 		log.Infoln("Reset Called Successfully!")


### PR DESCRIPTION
The client was logging an error even if one wasn't present due to a type mismatch (error vs *ResetError), adjusting the ResetTarget function to return a *ResetError seems to fix this