### PR TITLE
Device Connection History

### DIFF
--- a/gnxi_tester/cmd/run.go
+++ b/gnxi_tester/cmd/run.go
@@ -17,23 +17,36 @@ package cmd
 
 import (
 	log "github.com/golang/glog"
+	"github.com/google/gnxi/gnxi_tester/config"
 	"github.com/google/gnxi/gnxi_tester/orchestrator"
 	"github.com/spf13/cobra"
 )
 
-var runCmd = &cobra.Command{
-	Use:     "run",
-	Short:   "Run set of tests.",
-	Long:    "Run a set of tests from the config file",
-	Example: "gnxi_tester run [test_names]",
-	Run:     handleRun,
+var (
+	runCmd = &cobra.Command{
+		Use:     "run",
+		Short:   "Run set of tests.",
+		Long:    "Run a set of tests from the config file",
+		Example: "gnxi_tester run [test_names]",
+		Run:     handleRun,
+	}
+	targetName    string
+	targetAddress string
+)
+
+func init() {
+	runCmd.Flags().StringVarP(&targetName, "target_name", "n", "", "The name of the target to be tested")
+	runCmd.Flags().StringVarP(&targetAddress, "target_address", "a", "", "The address of the target to be tested")
 }
 
 // handleRun will run some or all of the tests.
 func handleRun(cmd *cobra.Command, args []string) {
+	if err := config.SetTarget(targetName, targetAddress); err != nil {
+		log.Exitf("Error writing config: %v", err)
+	}
 	if success, err := orchestrator.RunTests(args); err != nil {
-		log.Exit(err)
+		log.Exitf("Error running tests: %v", err)
 	} else {
-		log.Infof("tests run successfully: %s", success)
+		log.Infof("Tests ran successfully: %s", success)
 	}
 }

--- a/gnxi_tester/cmd/targets.go
+++ b/gnxi_tester/cmd/targets.go
@@ -16,31 +16,26 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/google/gnxi/gnxi_tester/config"
 	"github.com/spf13/cobra"
 )
 
 var (
-	rootCmd = &cobra.Command{
-		Use:   "gnxi_tester",
-		Short: "A client tester for the gNxI protocols.",
-		Long:  "A client utility that will run each of the client service binaries on a target and validate that the responses are correct.",
+	targetsCmd = &cobra.Command{
+		Use:     "targets",
+		Short:   "Displays target connection history.",
+		Example: "gnxi_tester run [test_names]",
+		Run:     displayTargets,
 	}
-	cfgPath string
 )
 
-func init() {
-	cobra.OnInitialize(initConfig)
-	rootCmd.AddCommand(runCmd)
-	rootCmd.AddCommand(targetsCmd)
-	rootCmd.PersistentFlags().StringVar(&cfgPath, "cfg", "", "Path to the config file.")
-}
-
-func initConfig() {
-	config.Init(cfgPath)
-}
-
-// Execute the root command.
-func Execute() error {
-	return rootCmd.Execute()
+// handleRun will run some or all of the tests.
+func displayTargets(cmd *cobra.Command, args []string) {
+	devices := config.GetDevices()
+	fmt.Printf("%20s%20s\n", "Target Name", "Target Address")
+	for name, address := range devices {
+		fmt.Printf("%20s%20s\n", name, address)
+	}
 }

--- a/gnxi_tester/config/config.go
+++ b/gnxi_tester/config/config.go
@@ -35,7 +35,7 @@ func Init(filePath string) {
 	setDefaults()
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile(filePath)
-	if err := viper.SafeWriteConfigAs(filePath); err != nil {
+	if err := viper.SafeWriteConfigAs(filePath); err != nil && err != viper.ConfigFileAlreadyExistsError(filePath) {
 		log.Exitf("couldn't write to config: %v", err)
 	}
 	if err := viper.ReadInConfig(); err != nil {
@@ -46,4 +46,10 @@ func Init(filePath string) {
 // GetTests will return tests from viper store.
 func GetTests() map[string][]Test {
 	return viper.Get("tests").(map[string][]Test)
+}
+
+// GetDevices will return target connection history from Viper store.
+func GetDevices() map[string]string {
+	devices := viper.GetStringMapString("targets.devices")
+	return devices
 }

--- a/gnxi_tester/config/config_test.go
+++ b/gnxi_tester/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/viper"
+)
+
+func TestGetDevices(t *testing.T) {
+	tests := []map[string]string{
+		{},
+		{"mydevice.com": "localhost:9339"},
+		{
+			"mydevice.com":      "localhost:9339",
+			"anotherdevice.com": ":9400",
+		},
+	}
+	for _, cfg := range tests {
+		viper.Set("targets.devices", cfg)
+		got := GetDevices()
+		if diff := cmp.Diff(cfg, got); diff != "" {
+			t.Errorf("GetDevices(): (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/gnxi_tester/config/history.go
+++ b/gnxi_tester/config/history.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/spf13/viper"
+)
+
+const defaultPort = ":9339"
+
+// SetTarget adds any new target to the target history.
+func SetTarget(targetName, targetAddress string) error {
+	devices := GetDevices()
+	if targetName == "" {
+		if len(devices) > 0 {
+			return nil
+		}
+		return errors.New("No targets in history and no target specified")
+	}
+	if devices[targetName] == "" {
+		if targetAddress == "" {
+			devices[targetName] = defaultPort
+		} else {
+			devices[targetName] = targetAddress
+		}
+	}
+	viper.Set("targets.last_target", targetName)
+	viper.Set("targets.devices", devices)
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #168
Acts as follows:
- If target name and address specified, add to history
- If target name without address:
    - Load address already used
    - Set address to :9339
- If target without address:
    - Use last device
    - If no devices in history, error