### PR TITLE
Added Cert Path to Known Targets

### DIFF
--- a/gnxi_tester/cmd/run.go
+++ b/gnxi_tester/cmd/run.go
@@ -28,6 +28,8 @@ import (
 var (
 	targetName    string
 	targetAddress string
+	ca            string
+	caKey         string
 	runCmd        = &cobra.Command{
 		Use:     "run",
 		Short:   "Run set of tests.",
@@ -41,11 +43,13 @@ var (
 func init() {
 	runCmd.Flags().StringVarP(&targetName, "target_name", "n", "", "The name of the target to be tested")
 	runCmd.Flags().StringVarP(&targetAddress, "target_address", "a", "", "The address of the target to be tested")
+	runCmd.Flags().StringVarP(&ca, "ca", "c", "", "The ca ")
+	runCmd.Flags().StringVarP(&caKey, "ca_key", "k", "", "The name of the target to be tested")
 }
 
 // handleRun will run some or all of the tests.
 func handleRun(cmd *cobra.Command, args []string) {
-	if err := config.SetTarget(targetName, targetAddress); err != nil {
+	if err := config.SetTarget(targetName, targetAddress, ca, caKey); err != nil {
 		log.Exitf("Error writing config: %v", err)
 	}
 	if success, err := orchestrator.RunTests(args, promptUser); err != nil {

--- a/gnxi_tester/cmd/targets.go
+++ b/gnxi_tester/cmd/targets.go
@@ -34,8 +34,8 @@ var (
 // handleRun will run some or all of the tests.
 func displayTargets(cmd *cobra.Command, args []string) {
 	devices := config.GetDevices()
-	fmt.Printf("%10s%20s%20s%20s\n", "Target Name", "Target Address", "CA", "CA Key")
+	fmt.Printf("%20s%20s%20s%20s\n", "Target Name", "Target Address", "CA", "CA Key")
 	for name, device := range devices {
-		fmt.Printf("%10s%20s%20s%20s\n", name, device.Address, device.Ca, device.CaKey)
+		fmt.Printf("%20s%20s%20s%20s\n", name, device.Address, device.Ca, device.CaKey)
 	}
 }

--- a/gnxi_tester/cmd/targets.go
+++ b/gnxi_tester/cmd/targets.go
@@ -34,8 +34,8 @@ var (
 // handleRun will run some or all of the tests.
 func displayTargets(cmd *cobra.Command, args []string) {
 	devices := config.GetDevices()
-	fmt.Printf("%20s%20s\n", "Target Name", "Target Address")
-	for name, address := range devices {
-		fmt.Printf("%20s%20s\n", name, address)
+	fmt.Printf("%10s%20s%20s%20s\n", "Target Name", "Target Address", "CA", "CA Key")
+	for name, device := range devices {
+		fmt.Printf("%10s%20s%20s%20s\n", name, device.Address, device.Ca, device.CaKey)
 	}
 }

--- a/gnxi_tester/config/config.go
+++ b/gnxi_tester/config/config.go
@@ -50,7 +50,6 @@ func GetTests() map[string][]Test {
 	if err := viper.UnmarshalKey("tests", &tests); err != nil {
 		return nil
 	}
-	fmt.Println(tests)
 	return tests
 }
 

--- a/gnxi_tester/config/config.go
+++ b/gnxi_tester/config/config.go
@@ -16,6 +16,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"path"
 
 	log "github.com/golang/glog"
@@ -31,12 +32,12 @@ func Init(filePath string) {
 			log.Exitf("couldn't get home directory: %v", err)
 		}
 		filePath = path.Join(home, ".gnxi.yml")
-		setDefaults()
 	}
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile(filePath)
+	setDefaults()
 	if err := viper.SafeWriteConfigAs(filePath); err != nil && err != viper.ConfigFileAlreadyExistsError(filePath) {
-		log.Exitf("couldn't write to config: %v", err)
+		log.Exitf("couldn't write config: %v", err)
 	}
 	if err := viper.ReadInConfig(); err != nil {
 		log.Exitf("couldn't read from config: %v", err)
@@ -49,6 +50,7 @@ func GetTests() map[string][]Test {
 	if err := viper.UnmarshalKey("tests", &tests); err != nil {
 		return nil
 	}
+	fmt.Println(tests)
 	return tests
 }
 

--- a/gnxi_tester/config/config.go
+++ b/gnxi_tester/config/config.go
@@ -31,8 +31,8 @@ func Init(filePath string) {
 			log.Exitf("couldn't get home directory: %v", err)
 		}
 		filePath = path.Join(home, ".gnxi.yml")
+		setDefaults()
 	}
-	setDefaults()
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile(filePath)
 	if err := viper.SafeWriteConfigAs(filePath); err != nil && err != viper.ConfigFileAlreadyExistsError(filePath) {
@@ -53,7 +53,8 @@ func GetTests() map[string][]Test {
 }
 
 // GetDevices will return target connection history from Viper store.
-func GetDevices() map[string]string {
-	devices := viper.GetStringMapString("targets.devices")
+func GetDevices() map[string]Device {
+	var devices map[string]Device
+	viper.UnmarshalKey("targets.devices", &devices)
 	return devices
 }

--- a/gnxi_tester/config/config.go
+++ b/gnxi_tester/config/config.go
@@ -16,7 +16,6 @@ limitations under the License.
 package config
 
 import (
-	"fmt"
 	"path"
 
 	log "github.com/golang/glog"

--- a/gnxi_tester/config/config_test.go
+++ b/gnxi_tester/config/config_test.go
@@ -43,17 +43,29 @@ func TestGetTests(t *testing.T) {
 		got := GetTests()
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("GetTests(): (-got +want):\n%s", diff)
-    }
-  }
+		}
+	}
 }
 
 func TestGetDevices(t *testing.T) {
-	tests := []map[string]string{
+	tests := []map[string]Device{
 		{},
-		{"mydevice.com": "localhost:9339"},
+		{"mydevice.com": Device{
+			Address: "localhost:9339",
+			Ca:      "ca.crt",
+			CaKey:   "ca.key",
+		}},
 		{
-			"mydevice.com":      "localhost:9339",
-			"anotherdevice.com": ":9400",
+			"mydevice.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			},
+			"anotherdevice.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			},
 		},
 	}
 	for _, cfg := range tests {

--- a/gnxi_tester/config/config_test.go
+++ b/gnxi_tester/config/config_test.go
@@ -84,6 +84,7 @@ func TestGetDevices(t *testing.T) {
 		},
 	}
 	for _, cfg := range tests {
+		viper.Reset()
 		viper.Set("targets.devices", cfg)
 		got := GetDevices()
 		if diff := cmp.Diff(cfg, got); diff != "" {

--- a/gnxi_tester/config/config_test.go
+++ b/gnxi_tester/config/config_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/gnxi_tester/config/defaults_test.go
+++ b/gnxi_tester/config/defaults_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+func TestGetDefaults(t *testing.T) {
+	got := generateTestCases()
+	if got == nil {
+		t.Errorf("Reset Tests Not Set!")
+	}
+	if got["gnoi_os"] == nil {
+		t.Errorf("OS Tests Not Set!")
+	}
+	if got["gnoi_cert"] == nil {
+		t.Errorf("Certificate Tests Not Set!")
+	}
+	if got["gnoi_reset"] == nil {
+		t.Errorf("Reset Tests Not Set!")
+	}
+}
+
+func TestSetDefaults(t *testing.T) {
+	want := generateTestCases()
+	setDefaults()
+	got := GetTests()
+	if diff := pretty.Compare(want, got); diff != "" {
+		t.Errorf("GetTests(): (-got +want):\n%s", diff)
+	}
+}

--- a/gnxi_tester/config/defaults_test.go
+++ b/gnxi_tester/config/defaults_test.go
@@ -1,47 +1,37 @@
-/* Copyright 2020 Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package config
 
 import (
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
+	"github.com/spf13/viper"
 )
 
-func TestGetDefaults(t *testing.T) {
+func TestGenerateTestCases(t *testing.T) {
 	got := generateTestCases()
 	if got == nil {
-		t.Errorf("Reset Tests Not Set!")
+		t.Errorf("Tests Not Defined!")
 	}
 	if got["gnoi_os"] == nil {
-		t.Errorf("OS Tests Not Set!")
+		t.Errorf("OS Tests Not Defined!")
 	}
 	if got["gnoi_cert"] == nil {
-		t.Errorf("Certificate Tests Not Set!")
+		t.Errorf("Certificate Tests Not Defined!")
 	}
 	if got["gnoi_reset"] == nil {
-		t.Errorf("Reset Tests Not Set!")
+		t.Errorf("Reset Tests Not Defined!")
 	}
 }
 
 func TestSetDefaults(t *testing.T) {
+	viper.Reset()
+	var got map[string][]Test
 	want := generateTestCases()
 	setDefaults()
-	got := GetTests()
+	if err := viper.UnmarshalKey("tests", &got); err != nil {
+		t.Errorf("Error getting tests: %v", err)
+	}
 	if diff := pretty.Compare(want, got); diff != "" {
-		t.Errorf("GetTests(): (-got +want):\n%s", diff)
+		t.Errorf("GetTests(): (-want +got):\n%s", diff)
 	}
 }

--- a/gnxi_tester/config/defaults_test.go
+++ b/gnxi_tester/config/defaults_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/gnxi_tester/config/history.go
+++ b/gnxi_tester/config/history.go
@@ -28,10 +28,9 @@ type Device struct {
 	CaKey   string `mapstructure:"cakey"`
 }
 
-// SetTarget adds any new target to the target history.
+// SetTarget adds any new target to the list of known targets.
 func SetTarget(targetName, targetAddress, ca, caKey string) error {
-	err := prepareTarget(targetName, targetAddress, ca, caKey)
-	if err != nil {
+	if err := prepareTarget(targetName, targetAddress, ca, caKey); err != nil {
 		return err
 	}
 	if err := viper.WriteConfig(); err != nil {
@@ -40,6 +39,7 @@ func SetTarget(targetName, targetAddress, ca, caKey string) error {
 	return nil
 }
 
+// prepareTarget parses provided details and creates or modifies target entry.
 func prepareTarget(targetName, targetAddress, ca, caKey string) error {
 	devices := GetDevices()
 	if devices == nil {

--- a/gnxi_tester/config/history.go
+++ b/gnxi_tester/config/history.go
@@ -6,28 +6,59 @@ import (
 	"github.com/spf13/viper"
 )
 
-const defaultPort = ":9339"
+// Device stores connection details of a target.
+type Device struct {
+	Address string `mapstructure:"address"`
+	Ca      string `mapstructure:"ca"`
+	CaKey   string `mapstructure:"cakey"`
+}
 
 // SetTarget adds any new target to the target history.
-func SetTarget(targetName, targetAddress string) error {
+func SetTarget(targetName, targetAddress, ca, caKey string) error {
+	err := prepareTarget(targetName, targetAddress, ca, caKey)
+	if err != nil {
+		return err
+	}
+	if err := viper.WriteConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func prepareTarget(targetName, targetAddress, ca, caKey string) error {
 	devices := GetDevices()
+	if devices == nil {
+		devices = map[string]Device{}
+	}
 	if targetName == "" {
 		if len(devices) > 0 {
 			return nil
 		}
 		return errors.New("No targets in history and no target specified")
 	}
-	if devices[targetName] == "" {
-		if targetAddress == "" {
-			devices[targetName] = defaultPort
-		} else {
-			devices[targetName] = targetAddress
+	if _, exists := devices[targetName]; !exists {
+		if targetAddress == "" || ca == "" || caKey == "" {
+			return errors.New("Device not found")
 		}
+		devices[targetName] = Device{
+			Address: targetAddress,
+			Ca:      ca,
+			CaKey:   caKey,
+		}
+	} else {
+		device := devices[targetName]
+		if targetAddress != "" {
+			device.Address = targetAddress
+		}
+		if ca != "" {
+			device.Ca = ca
+		}
+		if caKey != "" {
+			device.CaKey = caKey
+		}
+		devices[targetName] = device
 	}
 	viper.Set("targets.last_target", targetName)
 	viper.Set("targets.devices", devices)
-	if err := viper.WriteConfig(); err != nil {
-		return err
-	}
 	return nil
 }

--- a/gnxi_tester/config/history.go
+++ b/gnxi_tester/config/history.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/gnxi_tester/config/history_test.go
+++ b/gnxi_tester/config/history_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/spf13/viper"
+)
+
+type Want struct {
+	devices map[string]Device
+	err     error
+}
+
+func TestPrepareTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetName    string
+		targetAddress string
+		targetCA      string
+		targetCAKey   string
+		config        map[string]Device
+		lastTarget    string
+		want          Want
+	}{
+		{
+			name: "No targets in history, no target specified",
+			want: Want{
+				err:     errors.New("No targets in history and no target specified"),
+				devices: map[string]Device{},
+			},
+		},
+		{
+			name: "No target specified",
+			config: map[string]Device{"myhost.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			}},
+			lastTarget: "myhost.com",
+			want: Want{
+				err: nil,
+				devices: map[string]Device{"myhost.com": Device{
+					Address: "localhost:9339",
+					Ca:      "ca.crt",
+					CaKey:   "ca.key",
+				}},
+			},
+		},
+		{
+			name: "Non-existent device",
+			config: map[string]Device{"myhost.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			}},
+			targetName: "nonexistenttarget",
+			lastTarget: "myhost.com",
+			want: Want{
+				err: errors.New("Device not found"),
+				devices: map[string]Device{"myhost.com": Device{
+					Address: "localhost:9339",
+					Ca:      "ca.crt",
+					CaKey:   "ca.key",
+				}},
+			},
+		},
+		{
+			name:          "Add new target",
+			targetName:    "myhost.com",
+			targetAddress: "localhost:9339",
+			targetCA:      "ca.crt",
+			targetCAKey:   "ca.key",
+			want: Want{
+				devices: map[string]Device{
+					"myhost.com": {
+						Address: "localhost:9339",
+						Ca:      "ca.crt",
+						CaKey:   "ca.key",
+					},
+				},
+			},
+		},
+		{
+			name:          "Update existing device's address",
+			targetName:    "myhost.com",
+			targetAddress: "newhost:9340",
+			config: map[string]Device{"myhost.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			}},
+			want: Want{
+				devices: map[string]Device{
+					"myhost.com": {
+						Address: "newhost:9340",
+						Ca:      "ca.crt",
+						CaKey:   "ca.key",
+					},
+				},
+			},
+		},
+		{
+			name:       "Update existing device's ca",
+			targetName: "myhost.com",
+			targetCA:   "newca.crt",
+			config: map[string]Device{"myhost.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			}},
+			want: Want{
+				devices: map[string]Device{
+					"myhost.com": {
+						Address: "localhost:9339",
+						Ca:      "newca.crt",
+						CaKey:   "ca.key",
+					},
+				},
+			},
+		},
+		{
+			name:        "Update existing device's ca_key",
+			targetName:  "myhost.com",
+			targetCAKey: "newca.key",
+			config: map[string]Device{"myhost.com": Device{
+				Address: "localhost:9339",
+				Ca:      "ca.crt",
+				CaKey:   "ca.key",
+			}},
+			want: Want{
+				devices: map[string]Device{
+					"myhost.com": {
+						Address: "localhost:9339",
+						Ca:      "ca.crt",
+						CaKey:   "newca.key",
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var devices map[string]Device
+			viper.Set("targets.last_target", test.lastTarget)
+			viper.Set("targets.devices", test.config)
+			err := prepareTarget(test.targetName, test.targetAddress, test.targetCA, test.targetCAKey)
+			viper.UnmarshalKey("targets.devices", &devices)
+			got := Want{
+				devices: devices,
+				err:     err,
+			}
+			if diff := pretty.Compare(test.want, got); diff != "" {
+				t.Errorf("prepareTarget(%s, %s, %s, %s): (-want +got)\n%s", test.targetName, test.targetAddress, test.targetCA, test.targetCAKey, diff)
+			}
+		})
+	}
+}

--- a/gnxi_tester/config/history_test.go
+++ b/gnxi_tester/config/history_test.go
@@ -157,6 +157,7 @@ func TestPrepareTarget(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			viper.Reset()
 			var devices map[string]Device
 			viper.Set("targets.last_target", test.lastTarget)
 			viper.Set("targets.devices", test.config)

--- a/gnxi_tester/config/history_test.go
+++ b/gnxi_tester/config/history_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/gnxi_tester/orchestrator/run.go
+++ b/gnxi_tester/orchestrator/run.go
@@ -62,10 +62,13 @@ func RunTests(tests []string, prompt callbackFunc) (success []string, err error)
 func runTest(name string, prompt callbackFunc) (string, error) {
 	tests := configTests[name]
 	targetName := viper.GetString("targets.last_target")
+	target := config.GetDevices()[targetName]
 	defaultArgs := fmt.Sprintf(
-		"-logtostderr -target_name %s -target_addr %s",
+		"-logtostderr -target_name %s -target_addr %s -ca %s -ca_key %s",
 		targetName,
-		viper.GetStringMap("targets.devices")[targetName],
+		target.Address,
+		target.Ca,
+		target.CaKey,
 	)
 	stdout := fmt.Sprintf("*%s*:", name)
 	for _, test := range tests {

--- a/gnxi_tester/orchestrator/run_test.go
+++ b/gnxi_tester/orchestrator/run_test.go
@@ -55,7 +55,7 @@ func TestRunTests(t *testing.T) {
 				"test": {{Name: "test", Args: map[string]string{"ask": "&<ask>"}, Prompt: []string{"ask"}}},
 			},
 			func(name string) string { return name },
-			[]string{"*test*:\ntest:\n-ask ask -logtostderr -target_name test -target_addr test\n"},
+			[]string{"*test*:\ntest:\n-ask ask -logtostderr -target_name test -target_addr test -ca certs/ca.crt -ca_key certs/ca.key\n"},
 			nil,
 			func(name, args string) (out string, code int, err error) {
 				out = args
@@ -122,7 +122,7 @@ func TestRunTests(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			viper.Set("targets.devices", map[string]interface{}{"test": "test"})
+			viper.Set("targets.devices", map[string]config.Device{"test": config.Device{Address: "test", Ca: "certs/ca.crt", CaKey: "certs/ca.key"}})
 			viper.Set("targets.last_target", "test")
 			viper.Set("tests", test.tests)
 			runContainer = test.runContainer

--- a/gnxi_tester/orchestrator/run_test.go
+++ b/gnxi_tester/orchestrator/run_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2020 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package orchestrator
 
 import (


### PR DESCRIPTION
Removed setting default address
When initially using a target the user must provide the target's name, address, a CA and CA Key
Once added to connection history the user may reuse these details either by specifying the target's name, or entering nothing, then the client will use the last target specified
These details are overwritten if the user specifies the target name and any of the details.