### PR TITLE
Decoupled provision operation from cert

### DIFF
--- a/gnxi_tester/cmd/cmd.go
+++ b/gnxi_tester/cmd/cmd.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"flag"
+
 	"github.com/google/gnxi/gnxi_tester/config"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +27,9 @@ var (
 		Use:   "gnxi_tester",
 		Short: "A client tester for the gNxI protocols.",
 		Long:  "A client utility that will run each of the client service binaries on a target and validate that the responses are correct.",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			flag.CommandLine.Parse([]string{}) // Surpresses logging before flag.Parse error
+		},
 	}
 	cfgPath string
 )

--- a/gnxi_tester/cmd/run.go
+++ b/gnxi_tester/cmd/run.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 
 	log "github.com/golang/glog"
@@ -56,6 +57,7 @@ func handleRun(cmd *cobra.Command, args []string) {
 }
 
 func promptUser(name string) string {
+	fmt.Printf("Please provide %s: ", name)
 	out, err := scanner.ReadString('\n')
 	if err != nil {
 		log.Exitf("error reading line: %v", err)

--- a/gnxi_tester/config/defaults.go
+++ b/gnxi_tester/config/defaults.go
@@ -31,17 +31,19 @@ type Test struct {
 }
 
 func setDefaults() {
-	viper.SetDefault("tests", generateTestCases())
+	testCases, order := generateTestCases()
+	viper.SetDefault("tests", testCases)
+	viper.SetDefault("order", order)
 }
 
-func generateTestCases() map[string][]Test {
+func generateTestCases() (map[string][]Test, []string) {
+	provisionTest := []Test{{
+		Name:   "Provision Bootstrapping Target",
+		Args:   map[string]string{"op": "provision", "cert_id": "&<cert_id>"},
+		Wants:  "Install success",
+		Prompt: []string{"cert_id"},
+	}}
 	certTests := []Test{
-		{
-			Name:   "Provision Bootstrapping Target",
-			Args:   map[string]string{"op": "provision", "cert_id": "&<cert_id>"},
-			Wants:  "Install success",
-			Prompt: []string{"cert_id"},
-		},
 		{
 			Name:  "Get certs",
 			Args:  map[string]string{"op": "get"},
@@ -106,16 +108,9 @@ func generateTestCases() map[string][]Test {
 		},
 		{
 			Name:  "Verify Newly Installed OS",
-			Args:  map[string]string{"op": "verify", "version": "&<version>"},
+			Args:  map[string]string{"op": "verify"},
 			Wait:  20,
 			Wants: "Running OS Version: &<version>",
-		},
-		{
-			Name:     "Transfer an Incompatible OS",
-			Args:     map[string]string{"op": "install", "version": "&<incompatible_version>", "os": "&<incompatible_os_path>"},
-			MustFail: true,
-			Wants:    "Failed Install: InstallError occurred: INCOMPATIBLE",
-			Prompt:   []string{"incompatible_version", "incompatible_os_path"},
 		},
 		{
 			Name:     "Transfer Already Running OS",
@@ -124,18 +119,23 @@ func generateTestCases() map[string][]Test {
 			Wants:    "Failed Install: InstallError occured: INSTALL_RUN_PACKAGE",
 		},
 		{
-			Name:     "Parse OS Fails",
-			Args:     map[string]string{"op": "install", "version": "&<bad_os_version>", "os": "&<bad_os_path>"},
+			Name:     "Install another OS",
+			Args:     map[string]string{"op": "install", "version": "&<new_version>", "os": "&<new_os_path>"},
 			MustFail: true,
-			Wants:    "Failed Install: InstallError occured: PARSE_FAIL",
-			Prompt:   []string{"bad_os_version", "bad_os_path"},
+			Wait:     0,
+			Wants:    `^$`,
+			Prompt:   []string{"new_version", "new_os_path"},
 		},
 		{
-			Name:     "OS Integrity Check Fails",
-			Args:     map[string]string{"op": "install", "version": "&<bad_hash_version>", "os": "&<bad_hash_os>"},
-			MustFail: true,
-			Wants:    "Failed Install: InstallError occured: INTEGRITY_FAIL",
-			Prompt:   []string{"bad_hash_version", "bad_hash_os"},
+			Name:  "Activate Newly Installed OS",
+			Args:  map[string]string{"op": "activate", "version": "&<new_version>"},
+			Wants: `^$`,
+		},
+		{
+			Name:  "Verify Newly Installed OS",
+			Args:  map[string]string{"op": "verify"},
+			Wait:  20,
+			Wants: "Running OS Version: &<new_version>",
 		},
 		{
 			Name:   "Activate Non Existent Version",
@@ -144,5 +144,5 @@ func generateTestCases() map[string][]Test {
 			Prompt: []string{"non_existent_version"},
 		},
 	}
-	return map[string][]Test{"gnoi_os": osTests, "gnoi_reset": resetTests, "gnoi_cert": certTests}
+	return map[string][]Test{"gnoi_os": osTests, "gnoi_reset": resetTests, "gnoi_cert": certTests, "provision": provisionTest}, []string{"gnoi_os", "gnoi_cert", "gnoi_reset"}
 }

--- a/gnxi_tester/orchestrator/run.go
+++ b/gnxi_tester/orchestrator/run.go
@@ -41,16 +41,21 @@ var (
 func RunTests(tests []string, prompt callbackFunc) (success []string, err error) {
 	var output string
 	if len(tests) == 0 {
+		defaultOrder := viper.GetStringSlice("order")
 		configTests = config.GetTests()
-		for name := range configTests {
-			if output, err = runTest(name, prompt); err != nil {
+		provisionTests := configTests["provision"]
+		if output, err = runTest("gnoi_cert", prompt, provisionTests); err != nil {
+			return
+		}
+		for _, name := range defaultOrder {
+			if output, err = runTest(name, prompt, configTests[name]); err != nil {
 				return
 			}
 			success = append(success, output)
 		}
 	} else {
 		for _, name := range tests {
-			if output, err = runTest(name, prompt); err != nil {
+			if output, err = runTest(name, prompt, configTests[name]); err != nil {
 				return
 			}
 			success = append(success, output)
@@ -59,8 +64,7 @@ func RunTests(tests []string, prompt callbackFunc) (success []string, err error)
 	return
 }
 
-func runTest(name string, prompt callbackFunc) (string, error) {
-	tests := configTests[name]
+func runTest(name string, prompt callbackFunc, tests []config.Test) (string, error) {
 	targetName := viper.GetString("targets.last_target")
 	defaultArgs := fmt.Sprintf(
 		"-logtostderr -target_name %s -target_addr %s",

--- a/gnxi_tester/orchestrator/run_test.go
+++ b/gnxi_tester/orchestrator/run_test.go
@@ -14,6 +14,7 @@ func TestRunTests(t *testing.T) {
 		name         string
 		testNames    []string
 		tests        map[string][]config.Test
+		order        []string
 		prompt       callbackFunc
 		wantSucc     []string
 		wantErr      error
@@ -25,6 +26,7 @@ func TestRunTests(t *testing.T) {
 			map[string][]config.Test{
 				"test": {{Name: "test"}, {Name: "test2"}},
 			},
+			[]string{"test"},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n\ntest2:\ntest\n"},
 			nil,
@@ -39,6 +41,7 @@ func TestRunTests(t *testing.T) {
 			map[string][]config.Test{
 				"test": {{Name: "test", Args: map[string]string{"ask": "&<ask>"}, Prompt: []string{"ask"}}},
 			},
+			[]string{"test"},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\n-ask ask -logtostderr -target_name test -target_addr test\n"},
 			nil,
@@ -54,6 +57,7 @@ func TestRunTests(t *testing.T) {
 				"test":  {{Name: "test"}},
 				"test2": {{Name: "test2"}},
 			},
+			[]string{"test", "test2"},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n"},
 			nil,
@@ -68,6 +72,7 @@ func TestRunTests(t *testing.T) {
 			map[string][]config.Test{
 				"test": {{Name: "test", Wants: "test"}},
 			},
+			[]string{"test"},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n"},
 			nil,
@@ -82,6 +87,7 @@ func TestRunTests(t *testing.T) {
 			map[string][]config.Test{
 				"test": {{Name: "test", Wants: "no"}},
 			},
+			[]string{"test"},
 			func(name string) string { return name },
 			nil,
 			formateErr("test", "test", errors.New("Wanted no in output"), 0, false, "test", nil),
@@ -96,6 +102,7 @@ func TestRunTests(t *testing.T) {
 			map[string][]config.Test{
 				"test": {{Name: "test", DoesntWant: "aaaa"}},
 			},
+			[]string{"test"},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n"},
 			nil,
@@ -110,6 +117,7 @@ func TestRunTests(t *testing.T) {
 			viper.Set("targets.devices", map[string]interface{}{"test": "test"})
 			viper.Set("targets.last_target", "test")
 			viper.Set("tests", test.tests)
+			viper.Set("order", test.order)
 			runContainer = test.runContainer
 			succ, err := RunTests(test.testNames, test.prompt)
 			if diff := cmp.Diff(succ, test.wantSucc); diff != "" {


### PR DESCRIPTION
Added defaultOrder for default test: provision, cert, os, reset
Surpress log before flag.Parse error
Added order field to config
Provison op decoupled from cert
Refactored runTest to accept a set of tests as an arg
The order can be specified now
When a test isn't specified, the device is provisioned