### PR TITLE
RunContainer method for orchestrator.

### DIFF
--- a/gnxi_tester/cmd/cmd.go
+++ b/gnxi_tester/cmd/cmd.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"flag"
+
 	"github.com/google/gnxi/gnxi_tester/config"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +32,8 @@ var (
 )
 
 func init() {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
 	cobra.OnInitialize(initConfig)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(targetsCmd)

--- a/gnxi_tester/orchestrator/containers.go
+++ b/gnxi_tester/orchestrator/containers.go
@@ -125,6 +125,7 @@ func createContainer(name string) error {
 		return nil
 	}
 	if !found {
+		log.Infof("Building image for %s...", name)
 		_, err := dockerClient.ImageBuild(
 			context.Background(),
 			nil,
@@ -136,6 +137,7 @@ func createContainer(name string) error {
 		if err != nil {
 			return err
 		}
+		log.Infof("Finished building image for %s", name)
 	}
 	c, err := dockerClient.ContainerCreate(
 		context.Background(),
@@ -159,11 +161,13 @@ func pullImage(name string) error {
 		return nil
 	}
 	if !found {
+		log.Infof("Pulling image %s...", name)
 		closer, err := dockerClient.ImagePull(context.Background(), name, types.ImagePullOptions{})
 		if err != nil {
 			return err
 		}
 		closer.Close()
+		log.Infof("Finished pulling %s", name)
 	}
 	return nil
 }

--- a/gnxi_tester/orchestrator/containers.go
+++ b/gnxi_tester/orchestrator/containers.go
@@ -194,8 +194,10 @@ var RunContainer = func(name, args string) (out string, code int, err error) {
 	}
 	command := make([]string, len(args)+1)
 	command[0] = name
-	for i, arg := range strings.Split(args, " ") {
-		command[i] = arg
+	if len(args) > 0 {
+		for i, arg := range strings.Split(args, " ") {
+			command[i+1] = arg
+		}
 	}
 	var id types.IDResponse
 	if id, err = dockerClient.ContainerExecCreate(context.Background(), cont.ID, types.ExecConfig{Cmd: command}); err != nil {
@@ -233,7 +235,9 @@ var RunContainer = func(name, args string) (out string, code int, err error) {
 	}
 	code = inspect.ExitCode
 	out = outBuf.String()
-	err = errors.New(errBuf.String())
+	if errString := errBuf.String(); errString != "" {
+		err = errors.New(errString)
+	}
 	return
 }
 

--- a/gnxi_tester/orchestrator/containers.go
+++ b/gnxi_tester/orchestrator/containers.go
@@ -16,9 +16,12 @@ limitations under the License.
 package orchestrator
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"path"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -26,6 +29,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/google/gnxi/gnxi_tester/config"
 	"github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/stdcopy"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
@@ -38,6 +42,10 @@ type Client interface {
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImagePull(ctx context.Context, ref string, options types.ImagePullOptions) (io.ReadCloser, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
+	ContainerExecStart(ctx context.Context, execID string, config types.ExecStartCheck) error
+	ContainerExecAttach(ctx context.Context, execID string, config types.ExecConfig) (types.HijackedResponse, error)
+	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)
+	ContainerExecInspect(ctx context.Context, execID string) (types.ContainerExecInspect, error)
 }
 
 var dockerClient Client
@@ -81,7 +89,7 @@ func InitContainers(names []string) error {
 	}
 	for _, c := range containers {
 		for _, name := range c.Names {
-			if err := checkContainerExists(name, c, &names); err != nil {
+			if err := checkConatainerExists(name, c, &names); err != nil {
 				return err
 			}
 		}
@@ -94,7 +102,7 @@ func InitContainers(names []string) error {
 	return nil
 }
 
-func checkContainerExists(containerName string, cont types.Container, names *[]string) error {
+func checkConatainerExists(containerName string, cont types.Container, names *[]string) error {
 	for i, testName := range *names {
 		if containerName == testName {
 			if cont.Status != "running" {
@@ -180,5 +188,66 @@ imageCheck:
 
 // RunContainer runs an executable in a docker container.
 var RunContainer = func(name, args string) (out string, code int, err error) {
-	return "", 0, nil
+	var cont *types.Container
+	if cont, err = getContainer(name); err != nil {
+		return
+	}
+	command := make([]string, len(args)+1)
+	command[0] = name
+	for i, arg := range strings.Split(args, " ") {
+		command[i] = arg
+	}
+	var id types.IDResponse
+	if id, err = dockerClient.ContainerExecCreate(context.Background(), cont.ID, types.ExecConfig{Cmd: command}); err != nil {
+		return
+	}
+	if err = dockerClient.ContainerExecStart(context.Background(), id.ID, types.ExecStartCheck{}); err != nil {
+		return
+	}
+	var (
+		resp types.HijackedResponse
+		ctx  = context.Background()
+		done = make(chan error)
+		outBuf,
+		errBuf bytes.Buffer
+	)
+	if resp, err = dockerClient.ContainerExecAttach(ctx, id.ID, types.ExecConfig{}); err != nil {
+		return
+	}
+	defer resp.Close()
+	go func() {
+		_, err := stdcopy.StdCopy(&outBuf, &errBuf, resp.Reader)
+		done <- err
+	}()
+	select {
+	case err = <-done:
+		if err != nil {
+			return
+		}
+	case <-ctx.Done():
+		return
+	}
+	var inspect types.ContainerExecInspect
+	if inspect, err = dockerClient.ContainerExecInspect(context.Background(), id.ID); err != nil {
+		return
+	}
+	code = inspect.ExitCode
+	out = outBuf.String()
+	err = errors.New(errBuf.String())
+	return
+}
+
+func getContainer(name string) (*types.Container, error) {
+	containers, err := dockerClient.ContainerList(context.Background(), types.ContainerListOptions{All: true})
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range containers {
+		for _, containerName := range c.Names {
+			if containerName == name {
+				return &c, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("couldn't find container %s", name)
 }

--- a/gnxi_tester/orchestrator/containers.go
+++ b/gnxi_tester/orchestrator/containers.go
@@ -89,7 +89,7 @@ func InitContainers(names []string) error {
 	}
 	for _, c := range containers {
 		for _, name := range c.Names {
-			if err := checkConatainerExists(name, c, &names); err != nil {
+			if err := checkContainerExists(name, c, &names); err != nil {
 				return err
 			}
 		}
@@ -102,7 +102,7 @@ func InitContainers(names []string) error {
 	return nil
 }
 
-func checkConatainerExists(containerName string, cont types.Container, names *[]string) error {
+func checkContainerExists(containerName string, cont types.Container, names *[]string) error {
 	for i, testName := range *names {
 		if containerName == testName {
 			if cont.Status != "running" {

--- a/gnxi_tester/orchestrator/containers_test.go
+++ b/gnxi_tester/orchestrator/containers_test.go
@@ -223,7 +223,7 @@ func TestRunContainer(t *testing.T) {
 		{
 			"run successfully",
 			"name",
-			"",
+			"arg",
 			clientCounter{
 				CountContainerList:        1,
 				CountContainerExecStart:   1,

--- a/gnxi_tester/orchestrator/run.go
+++ b/gnxi_tester/orchestrator/run.go
@@ -39,6 +39,7 @@ var (
 
 // RunTests will take in test name and run each test or all tests.
 func RunTests(tests []string, prompt callbackFunc) (success []string, err error) {
+	InitContainers(tests)
 	var output string
 	if len(tests) == 0 {
 		configTests = config.GetTests()


### PR DESCRIPTION
Related issue: Close #173
RunContainer will create an exec process in the running container and use it to run the binary with the provided flags. It will then split the standard streams from the process into stdout and stderr and return them separately.