### PR TITLE
Added --files fixes and reduced chunk size in OS Install

### DIFF
--- a/gnoi/os/client.go
+++ b/gnoi/os/client.go
@@ -50,7 +50,7 @@ type Client struct {
 	client pb.OSClient
 }
 
-const chunkSize = 5000000
+const chunkSize = 4000000 // 4MB
 
 // NewClient returns a new OS service client.
 func NewClient(c *grpc.ClientConn) *Client {

--- a/gnoi/os/client.go
+++ b/gnoi/os/client.go
@@ -50,7 +50,6 @@ type Client struct {
 	client pb.OSClient
 }
 
-var readChunkSize uint64 = 4000000
 
 // NewClient returns a new OS service client.
 func NewClient(c *grpc.ClientConn) *Client {
@@ -59,7 +58,6 @@ func NewClient(c *grpc.ClientConn) *Client {
 
 // Install invokes the Install RPC for the OS service.
 func (c *Client) Install(ctx context.Context, imgPath, version string, validateTimeout time.Duration, chunkSize uint64) error {
-	readChunkSize = chunkSize
 	file, fileSize, fileClose, err := fileReader(imgPath)
 	if err != nil {
 		return err
@@ -147,8 +145,8 @@ func (c *Client) Install(ctx context.Context, imgPath, version string, validateT
 	// image each time.
 	go func() {
 		var readSize int
-		b := make([]byte, readChunkSize)
-		for n := int64(0); n < int64(fileSize)+int64(readChunkSize); n += int64(readChunkSize) {
+		b := make([]byte, chunkSize)
+		for n := int64(0); n < int64(fileSize)+int64(chunkSize); n += int64(chunkSize) {
 			if readSize, err = file.ReadAt(b, n); err != nil && err != io.EOF {
 				errs <- err
 				return

--- a/gnoi/os/client_test.go
+++ b/gnoi/os/client_test.go
@@ -152,14 +152,14 @@ func TestInstall(t *testing.T) {
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{}},
-					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: chunkSize}}},
+					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: readChunkSize}}},
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferEnd{}},
 					&pb.InstallResponse{Response: &pb.InstallResponse_Validated{Validated: &pb.Validated{}}},
 				},
 			},
-			readBytes(chunkSize),
+			readBytes(int(readChunkSize)),
 			nil,
 			100 * time.Millisecond,
 		},
@@ -172,22 +172,22 @@ func TestInstall(t *testing.T) {
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{}},
-					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: chunkSize}}},
+					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: readChunkSize}}},
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{}},
-					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: (chunkSize * 2)}}},
+					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: (readChunkSize * 2)}}},
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{}},
-					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: (chunkSize * 2) + 1}}},
+					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: (readChunkSize * 2) + 1}}},
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferEnd{}},
 					&pb.InstallResponse{Response: &pb.InstallResponse_Validated{Validated: &pb.Validated{}}},
 				},
 			},
-			readBytes((chunkSize * 2) + 1),
+			readBytes((int(readChunkSize) * 2) + 1),
 			nil,
 			100 * time.Millisecond,
 		},
@@ -203,7 +203,7 @@ func TestInstall(t *testing.T) {
 					&pb.InstallResponse{Response: &pb.InstallResponse_InstallError{InstallError: &pb.InstallError{Type: pb.InstallError_INCOMPATIBLE}}},
 				},
 			},
-			readBytes(chunkSize),
+			readBytes(int(readChunkSize)),
 			errors.New("InstallError occurred: INCOMPATIBLE"),
 			100 * time.Millisecond,
 		},
@@ -243,7 +243,7 @@ func TestInstall(t *testing.T) {
 					&pb.InstallResponse{Response: &pb.InstallResponse_InstallError{InstallError: &pb.InstallError{Type: pb.InstallError_UNSPECIFIED, Detail: "Unspecified"}}},
 				},
 			},
-			readBytes(chunkSize * 2),
+			readBytes(int(readChunkSize) * 2),
 			errors.New("Unspecified InstallError error: Unspecified"),
 			100 * time.Millisecond,
 		},
@@ -256,14 +256,14 @@ func TestInstall(t *testing.T) {
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{}},
-					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: chunkSize}}},
+					&pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{TransferProgress: &pb.TransferProgress{BytesReceived: readChunkSize}}},
 				},
 				{
 					&pb.InstallRequest{Request: &pb.InstallRequest_TransferEnd{}},
 					nil,
 				},
 			},
-			readBytes(chunkSize),
+			readBytes(int(readChunkSize)),
 			errors.New("Validation timed out"),
 			50 * time.Millisecond,
 		},
@@ -278,7 +278,7 @@ func TestInstall(t *testing.T) {
 				}},
 			}
 			fileReader = test.reader
-			if err := client.Install(context.Background(), "", "version", test.timeout); fmt.Sprintf("%v", err) != fmt.Sprintf("%v", test.err) {
+			if err := client.Install(context.Background(), "", "version", test.timeout, readChunkSize); fmt.Sprintf("%v", err) != fmt.Sprintf("%v", test.err) {
 				t.Errorf("Wanted error: **%v** but got error: **%v**", test.err, err)
 			}
 		})

--- a/gnoi/os/client_test.go
+++ b/gnoi/os/client_test.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const readChunkSize = 4000000
+const readChunkSize = 4000000 // 4MB. Highest amount of data a chunk should be since >5MB will cause a grpc transport error.
 
 type activateRPC func(ctx context.Context, in *pb.ActivateRequest, opts ...grpc.CallOption) (*pb.ActivateResponse, error)
 type verifyRPC func(ctx context.Context, in *pb.VerifyRequest, opts ...grpc.CallOption) (*pb.VerifyResponse, error)

--- a/gnoi/os/client_test.go
+++ b/gnoi/os/client_test.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const readChunkSize = 4000000
+
 type activateRPC func(ctx context.Context, in *pb.ActivateRequest, opts ...grpc.CallOption) (*pb.ActivateResponse, error)
 type verifyRPC func(ctx context.Context, in *pb.VerifyRequest, opts ...grpc.CallOption) (*pb.VerifyResponse, error)
 

--- a/gnoi/os/manager.go
+++ b/gnoi/os/manager.go
@@ -29,8 +29,9 @@ type Manager struct {
 
 // Settings wraps OS Server initialization options.
 type Settings struct {
-	FactoryVersion    string
-	InstalledVersions []string
+	FactoryVersion      string
+	InstalledVersions   []string
+	ReceiveChunkSizeAck uint64
 }
 
 // NewManager for OS service module. Will manage state of OS module.

--- a/gnoi/os/server.go
+++ b/gnoi/os/server.go
@@ -23,9 +23,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	targetChunkSize = 12000000 // 12MB
-)
+var receiveChunkSizeAck uint64 = 12000000
 
 // Server is an OS Management service.
 type Server struct {
@@ -36,6 +34,9 @@ type Server struct {
 
 // NewServer returns an OS Management service.
 func NewServer(settings *Settings) *Server {
+	if settings.ReceiveChunkSizeAck != 0 {
+		receiveChunkSizeAck = settings.ReceiveChunkSizeAck
+	}
 	server := &Server{
 		manager:      NewManager(settings.FactoryVersion),
 		installToken: make(chan bool, 1),
@@ -184,7 +185,7 @@ func ReceiveOS(stream pb.OS_InstallServer) (*bytes.Buffer, error) {
 			utils.LogProto(in)
 			return nil, errors.New("Unknown request type")
 		}
-		if curr := bb.Len() / targetChunkSize; curr > prev {
+		if curr := bb.Len() / int(receiveChunkSizeAck); curr > prev {
 			prev = curr
 			response := &pb.InstallResponse{Response: &pb.InstallResponse_TransferProgress{
 				TransferProgress: &pb.TransferProgress{BytesReceived: uint64(bb.Len())},

--- a/gnoi/os/server.go
+++ b/gnoi/os/server.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	targetChunkSize = 10000000 // 10MB
+	targetChunkSize = 12000000 // 12MB
 )
 
 // Server is an OS Management service.

--- a/gnoi/os/server_test.go
+++ b/gnoi/os/server_test.go
@@ -64,7 +64,7 @@ func (m mockTransferStream) Recv() (*pb.InstallRequest, error) {
 			if m.os.MockOS.Padding != nil {
 				out, _ = proto.Marshal(&m.os.MockOS)
 			} else {
-				out = make([]byte, 10000000)
+				out = make([]byte, targetChunkSize)
 				rand.Read(out)
 			}
 			return &pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{TransferContent: out}}, nil
@@ -210,7 +210,7 @@ func TestTargetActivateAndVerify(t *testing.T) {
 }
 
 func TestTargetReceiveOS(t *testing.T) {
-	buf := make([]byte, 10000000)
+	buf := make([]byte, targetChunkSize)
 	rand.Read(buf)
 	oS := &mockos.OS{MockOS: mockosPb.MockOS{
 		Version: "1.0.2a",
@@ -253,7 +253,7 @@ func TestTargetReceiveOS(t *testing.T) {
 }
 
 func TestTargetInstall(t *testing.T) {
-	buf := make([]byte, 10000000)
+	buf := make([]byte, targetChunkSize)
 	rand.Read(buf)
 	oS := &mockos.OS{MockOS: mockosPb.MockOS{
 		Version: "1.0.2a",
@@ -390,7 +390,7 @@ func TestTargetInstall(t *testing.T) {
 // TestMultipleInstalls tests for mutual exclusion in the install service.
 func TestMultipleInstalls(t *testing.T) {
 	t.Run("testing mutual exclusion in install service", func(t *testing.T) {
-		buf := make([]byte, 10000000)
+		buf := make([]byte, targetChunkSize)
 		rand.Read(buf)
 		oS := &mockos.OS{MockOS: mockosPb.MockOS{
 			Version: "1.0.2a",

--- a/gnoi/os/server_test.go
+++ b/gnoi/os/server_test.go
@@ -64,7 +64,7 @@ func (m mockTransferStream) Recv() (*pb.InstallRequest, error) {
 			if m.os.MockOS.Padding != nil {
 				out, _ = proto.Marshal(&m.os.MockOS)
 			} else {
-				out = make([]byte, targetChunkSize)
+				out = make([]byte, receiveChunkSizeAck)
 				rand.Read(out)
 			}
 			return &pb.InstallRequest{Request: &pb.InstallRequest_TransferContent{TransferContent: out}}, nil
@@ -210,7 +210,7 @@ func TestTargetActivateAndVerify(t *testing.T) {
 }
 
 func TestTargetReceiveOS(t *testing.T) {
-	buf := make([]byte, targetChunkSize)
+	buf := make([]byte, receiveChunkSizeAck)
 	rand.Read(buf)
 	oS := &mockos.OS{MockOS: mockosPb.MockOS{
 		Version: "1.0.2a",
@@ -253,7 +253,7 @@ func TestTargetReceiveOS(t *testing.T) {
 }
 
 func TestTargetInstall(t *testing.T) {
-	buf := make([]byte, targetChunkSize)
+	buf := make([]byte, receiveChunkSizeAck)
 	rand.Read(buf)
 	oS := &mockos.OS{MockOS: mockosPb.MockOS{
 		Version: "1.0.2a",
@@ -390,7 +390,7 @@ func TestTargetInstall(t *testing.T) {
 // TestMultipleInstalls tests for mutual exclusion in the install service.
 func TestMultipleInstalls(t *testing.T) {
 	t.Run("testing mutual exclusion in install service", func(t *testing.T) {
-		buf := make([]byte, targetChunkSize)
+		buf := make([]byte, receiveChunkSizeAck)
 		rand.Read(buf)
 		oS := &mockos.OS{MockOS: mockosPb.MockOS{
 			Version: "1.0.2a",

--- a/gnoi_os/gnoi_os.go
+++ b/gnoi_os/gnoi_os.go
@@ -33,7 +33,7 @@ var (
 	osFile        = flag.String("os", "", "Path to the OS image for the install operation")
 	op            = flag.String("op", "", "OS service operation. Can be one of: install, activate, verify")
 	timeOut       = flag.Duration("time_out", 5*time.Second, "Timeout for the operation, 5 seconds by default")
-	readChunkSize = flag.Uint64("chunk_size", 4000000, "The chunk size of the image to send in bytes. Example: -chunk_size 4000000")
+	readChunkSize = flag.Uint64("chunk_size", 4000000, "How much of the image to laod a time, in bytes. Example: -chunk_size 4000000")
 
 	client *gnoiOS.Client
 	ctx    context.Context

--- a/gnoi_os/gnoi_os.go
+++ b/gnoi_os/gnoi_os.go
@@ -33,7 +33,7 @@ var (
 	osFile        = flag.String("os", "", "Path to the OS image for the install operation")
 	op            = flag.String("op", "", "OS service operation. Can be one of: install, activate, verify")
 	timeOut       = flag.Duration("time_out", 5*time.Second, "Timeout for the operation, 5 seconds by default")
-	readChunkSize = flag.Uint64("chunk_size", 4000000, "How much of the image to laod a time, in bytes. Example: -chunk_size 4000000")
+	readChunkSize = flag.Uint64("chunk_size", 4000000, "How much of the image to load a time, in bytes. Example: -chunk_size 4000000")
 
 	client *gnoiOS.Client
 	ctx    context.Context

--- a/gnoi_os/gnoi_os.go
+++ b/gnoi_os/gnoi_os.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	targetAddr = flag.String("target_addr", ":9339", "The target address in the format of host:port")
-	targetName = flag.String("target_name", "", "The target name used to verify the hostname returned by TLS handshake")
-	version    = flag.String("version", "", "Version of the OS required when using the activate operation or being installed using the install operation")
-	osFile     = flag.String("os", "", "Path to the OS image for the install operation")
-	op         = flag.String("op", "", "OS service operation. Can be one of: install, activate, verify")
-	timeOut    = flag.Duration("time_out", 5*time.Second, "Timeout for the operation, 5 seconds by default")
+	targetAddr    = flag.String("target_addr", ":9339", "The target address in the format of host:port")
+	targetName    = flag.String("target_name", "", "The target name used to verify the hostname returned by TLS handshake")
+	version       = flag.String("version", "", "Version of the OS required when using the activate operation or being installed using the install operation")
+	osFile        = flag.String("os", "", "Path to the OS image for the install operation")
+	op            = flag.String("op", "", "OS service operation. Can be one of: install, activate, verify")
+	timeOut       = flag.Duration("time_out", 5*time.Second, "Timeout for the operation, 5 seconds by default")
+	readChunkSize = flag.Uint64("chunk_size", 4000000, "The chunk size of the image to send in bytes. Example: -chunk_size 4000000")
 
 	client *gnoiOS.Client
 	ctx    context.Context
@@ -78,7 +79,7 @@ func install() {
 	if *version == "" {
 		log.Exit("No version provided. Provide one with -version")
 	}
-	if err := client.Install(ctx, *osFile, *version, *timeOut); err != nil {
+	if err := client.Install(ctx, *osFile, *version, *timeOut, *readChunkSize); err != nil {
 		log.Exit("Failed Install: ", err)
 	}
 }

--- a/gnoi_target/gnoi_target.go
+++ b/gnoi_target/gnoi_target.go
@@ -46,6 +46,7 @@ var (
 	factoryOSUnsupported = flag.Bool("reset_unsupported", false, "Make the target not support factory resetting OS")
 	factoryVersion       = flag.String("factoryOS_version", "1.0.0a", "Specify factory OS version, 1.0.0a by default")
 	installedVersions    = flag.String("installedOS_versions", "", "Specify installed OS versions, e.g \"1.0.1a 2.01b\"")
+	receiveChunkSizeAck  = flag.Uint64("chunk_size_ack", 12000000, "The chunk size of the image to respond with a TransfreResponse in bytes. Example: -chunk_size 12000000")
 )
 
 // serve binds to an address and starts serving a gRPCServer.
@@ -101,8 +102,9 @@ func start() {
 		FactoryOSUnsupported: *factoryOSUnsupported,
 	}
 	osSettings := &os.Settings{
-		FactoryVersion:    *factoryVersion,
-		InstalledVersions: strings.Split(*installedVersions, " "),
+		FactoryVersion:      *factoryVersion,
+		InstalledVersions:   strings.Split(*installedVersions, " "),
+		ReceiveChunkSizeAck: *receiveChunkSizeAck,
 	}
 	var (
 		numCerts,

--- a/gnxi_tester/README.md
+++ b/gnxi_tester/README.md
@@ -2,15 +2,35 @@
 
 A CLI tool for orchestrating tests against a gNXI target.
 
-## Install
+## CLI
+
+### Installing
 
 ```
 go get github.com/google/gnxi/gnxi_tester
 go install github.com/google/gnxi/gnxi_tester
 ```
 
-## Run
+### Running
 
+Tests are provided in `~/.gnxi.yml`. By default, the following services will be run: 
+- `provision`
+- `gnoi_os`
+- `gnoi_cert`
+- `gnoi_reset`
+
+If `[test_names]` are provided, only those tests are ran.
 ```
-./gnxi_tester run [test_names]
+gnxi_tester run [test_names] \ 
+--cert certs/ca.crt \
+--key certs/ca.key \
+--target_name target.com \
+--target_address localhost:9339 \
+--files "os_path:/path/to/image other_file:/path_to_file"
 ```
+
+### Files required by service
+Files to be passed in the `--files` flag.
+#### `gnoi_os`
+- `os_path`: Path to OS file used in `install` operation.
+

--- a/gnxi_tester/README.md
+++ b/gnxi_tester/README.md
@@ -13,7 +13,7 @@ go install github.com/google/gnxi/gnxi_tester
 
 ### Running
 
-Tests are provided in `~/.gnxi.yml`. By default, the following services will be run: 
+Tests are provided in `~/.gnxi.yml`. By default, the following processes & clients will be run: 
 - `provision`
 - `gnoi_os`
 - `gnoi_cert`

--- a/gnxi_tester/README.md
+++ b/gnxi_tester/README.md
@@ -19,6 +19,61 @@ Tests are provided in `~/.gnxi.yml`. By default, the following processes & clien
 - `gnoi_cert`
 - `gnoi_reset`
 
+For example, the auto generated `~/.gnxi.yml` will look like:
+```yml
+docker:
+  build: golang:1.14-alpine
+  runtime: alpine:latest
+order:
+- gnoi_os
+- gnoi_cert
+- gnoi_reset
+tests:
+  gnoi_cert:
+  - args:
+      op: get
+    doesntwant: ""
+    mustfail: false
+    name: Get certs
+    prompt: []
+    wait: 10
+    wants: GetCertificates:\n{\w*
+    [...]
+  gnoi_os:
+  - args:
+      op: install
+      os: '&<os_path>'
+      version: '&<os_version>' # escaped variables the user will be prompted for
+    doesntwant: ""
+    mustfail: false
+    name: Compatible OS with Good Hash Install
+    prompt:
+    - os_version
+    - os_path
+    wait: 0
+    wants: ^$
+    [...]
+  gnoi_reset:
+  - args: {}
+    doesntwant: ""
+    mustfail: false
+    name: Resetting a Target Successfully
+    prompt: []
+    wait: 0
+    wants: ^$
+  provision:
+  - args:
+      cert_id: '&<cert_id>'
+      op: provision
+    doesntwant: ""
+    mustfail: false
+    name: Provision Bootstrapping Target
+    prompt:
+    - cert_id
+    wait: 0
+    wants: Install success
+```
+
 If `[test_names]` are provided, only those tests are ran.
 ```
 gnxi_tester run [test_names] \ 

--- a/gnxi_tester/cmd/run.go
+++ b/gnxi_tester/cmd/run.go
@@ -49,7 +49,7 @@ func init() {
 	runCmd.Flags().StringVarP(&targetAddress, "target_address", "a", "", "The address of the target to be tested")
 	runCmd.Flags().StringVarP(&ca, "ca", "c", "", "The ca ")
 	runCmd.Flags().StringVarP(&caKey, "ca_key", "k", "", "The key for the ca file")
-	runCmd.Flags().StringVarP(&files, "files", "f", "", "Extra files used for tests. Example: -f \"os:/path/to/os file:/path/to/other/file\"")
+	runCmd.Flags().StringVarP(&files, "files", "f", "", "Extra files used for tests. Example: -f \"os_path:/path/to/os file:/path/to/other/file\"")
 }
 
 // handleRun will run some or all of the tests.
@@ -60,7 +60,7 @@ func handleRun(cmd *cobra.Command, args []string) {
 	if success, err := orchestrator.RunTests(args, promptUser, parseFiles()); err != nil {
 		log.Exitf("Error running tests: %v", err)
 	} else {
-		log.Infof("Tests ran successfully: %s", success)
+		log.Infof("Tests ran successfully: \n\n%s", success)
 	}
 }
 

--- a/gnxi_tester/cmd/run.go
+++ b/gnxi_tester/cmd/run.go
@@ -67,6 +67,7 @@ func handleRun(cmd *cobra.Command, args []string) {
 func parseFiles() map[string]string {
 	out := map[string]string{}
 	for _, file := range strings.Split(files, " ") {
+		file = strings.ReplaceAll(file, "\"", "")
 		if len(file) > 1 {
 			vals := strings.SplitN(file, ":", 2)
 			if len(vals) > 1 {

--- a/gnxi_tester/config/defaults.go
+++ b/gnxi_tester/config/defaults.go
@@ -40,6 +40,9 @@ func setDefaults() {
 	viper.SetDefault("docker.runtime", "alpine:latest")
 	viper.SetDefault("docker.files", createDockerfiles(testCases))
 	viper.SetDefault("order", order)
+	viper.SetDefault("files", map[string][]string{
+		"gnoi_os": {"os_path"},
+	})
 
 }
 

--- a/gnxi_tester/config/defaults.go
+++ b/gnxi_tester/config/defaults.go
@@ -41,7 +41,7 @@ func setDefaults() {
 	viper.SetDefault("docker.files", createDockerfiles(testCases))
 	viper.SetDefault("order", order)
 	viper.SetDefault("files", map[string][]string{
-		"gnoi_os": {"os_path"},
+		"gnoi_os": {"os_path", "new_os_path"},
 	})
 
 }
@@ -102,7 +102,7 @@ func generateTestCases() (Tests, []string) {
 			Name:   "Compatible OS with Good Hash Install",
 			Args:   map[string]string{"op": "install", "version": "&<os_version>", "os": "&<os_path>"},
 			Wants:  `^$`,
-			Prompt: []string{"os_version", "os_path"},
+			Prompt: []string{"os_version"},
 		},
 		{
 			Name:     "Install Already Installed OS",
@@ -134,7 +134,7 @@ func generateTestCases() (Tests, []string) {
 			MustFail: true,
 			Wait:     0,
 			Wants:    `^$`,
-			Prompt:   []string{"new_os_version", "new_os_path"},
+			Prompt:   []string{"new_os_version"},
 		},
 		{
 			Name:  "Activate Newly Installed OS",

--- a/gnxi_tester/orchestrator/containers.go
+++ b/gnxi_tester/orchestrator/containers.go
@@ -17,7 +17,6 @@ package orchestrator
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -107,7 +106,7 @@ var InitContainers = func(names []string) error {
 
 func checkContainerExists(containerName string, cont types.Container, names *[]string) error {
 	for i, testName := range *names {
-		if containerName == "/" + testName {
+		if containerName == "/"+testName {
 			if cont.State != "running" {
 				if err := dockerClient.ContainerStart(context.Background(), cont.ID, types.ContainerStartOptions{}); err != nil {
 					return err
@@ -291,7 +290,7 @@ func getContainer(name string) (*types.Container, error) {
 	}
 	for _, c := range containers {
 		for _, containerName := range c.Names {
-			if containerName == "/"+ name {
+			if containerName == "/"+name {
 				return &c, nil
 			}
 		}
@@ -301,10 +300,13 @@ func getContainer(name string) (*types.Container, error) {
 
 var tarFile = func(name, filePath string) (io.ReadCloser, error) {
 	loc := path.Join("/tmp", fmt.Sprintf("%s.tar.gz", name))
-	if _, err := os.Stat(loc); errors.Is(err, os.ErrNotExist) {
-		if err := archiver.Archive([]string{filePath}, loc); err != nil {
+	if _, err := os.Stat(loc); !os.IsNotExist(err) {
+		if err = os.Remove(loc); err != nil {
 			return nil, err
 		}
+	}
+	if err := archiver.Archive([]string{filePath}, loc); err != nil {
+		return nil, err
 	}
 	f, err := os.Open(loc)
 	if err != nil {

--- a/gnxi_tester/orchestrator/run.go
+++ b/gnxi_tester/orchestrator/run.go
@@ -87,12 +87,12 @@ func runTest(name string, prompt callbackFunc, tests []config.Test) (string, err
 		for _, p := range test.Prompt {
 			input[p] = prompt(p)
 		}
-		test.DoesntWant = insertVars(test.DoesntWant, []string{})
-		test.Wants = insertVars(test.Wants, []string{})
+		test.DoesntWant = insertVars(test.DoesntWant, &[]string{})
+		test.Wants = insertVars(test.Wants, &[]string{})
 		binArgs := defaultArgs
 		insertFiles := []string{}
 		for arg, val := range test.Args {
-			binArgs = fmt.Sprintf("-%s %s %s", arg, insertVars(val, insertFiles), binArgs)
+			binArgs = fmt.Sprintf("-%s %s %s", arg, insertVars(val, &insertFiles), binArgs)
 		}
 		out, code, err := RunContainer(name, binArgs, &target, insertFiles)
 		if exp := expects(out, &test); (code == 0) == test.MustFail || err != nil || exp != nil {
@@ -133,13 +133,13 @@ func formatErr(major, minor, out string, custom error, code int, fail bool, err 
 	)
 }
 
-func insertVars(in string, insertFiles []string) string {
+func insertVars(in string, insertFiles *[]string) string {
 	matches := delimRe.FindAllString(in, -1)
 	for _, match := range matches {
 		name := match[2 : len(match)-1]
 		if f, ok := files[name]; ok {
 			in = strings.Replace(in, match, path.Join("/tmp", path.Base(f)), 1)
-			insertFiles = append(insertFiles, f)
+			*insertFiles = append(*insertFiles, f)
 		} else {
 			in = strings.Replace(in, match, input[name], 1)
 		}

--- a/gnxi_tester/orchestrator/run.go
+++ b/gnxi_tester/orchestrator/run.go
@@ -18,6 +18,7 @@ package orchestrator
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -43,6 +44,7 @@ var (
 // RunTests will take in test name and run each test or all tests.
 func RunTests(tests []string, prompt callbackFunc, userFiles map[string]string) (success []string, err error) {
 	files = userFiles
+	required := viper.GetStringMapStringSlice("files")
 	defaultOrder := viper.GetStringSlice("order")
 	if err = InitContainers(defaultOrder); err != nil {
 		return
@@ -50,6 +52,11 @@ func RunTests(tests []string, prompt callbackFunc, userFiles map[string]string) 
 	configTests = config.GetTests()
 	var output string
 	if len(tests) == 0 {
+		for test, fs := range required {
+			if err = checkFileProvided(fs, test, prompt); err != nil {
+				return
+			}
+		}
 		defaultOrder = viper.GetStringSlice("order")
 		provisionTests := configTests["provision"]
 		if output, err = runTest("gnoi_cert", prompt, provisionTests); err != nil {
@@ -62,6 +69,13 @@ func RunTests(tests []string, prompt callbackFunc, userFiles map[string]string) 
 			success = append(success, output)
 		}
 	} else {
+		for _, test := range tests {
+			if fs, ok := required[test]; ok {
+				if err = checkFileProvided(fs, test, prompt); err != nil {
+					return
+				}
+			}
+		}
 		for _, name := range tests {
 			if output, err = runTest(name, prompt, configTests[name]); err != nil {
 				return
@@ -70,6 +84,19 @@ func RunTests(tests []string, prompt callbackFunc, userFiles map[string]string) 
 		}
 	}
 	return
+}
+
+func checkFileProvided(fs []string, name string, prompt callbackFunc) error {
+	for _, f := range fs {
+		if _, ok := files[f]; !ok {
+			var err error
+			files[f], err = filepath.Abs(prompt(fmt.Sprintf("%s for %s (relative or absolute file path)", f, name)))
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func runTest(name string, prompt callbackFunc, tests []config.Test) (string, error) {

--- a/gnxi_tester/orchestrator/run_test.go
+++ b/gnxi_tester/orchestrator/run_test.go
@@ -30,6 +30,7 @@ func TestRunTests(t *testing.T) {
 		testNames    []string
 		tests        map[string][]config.Test
 		order        []string
+		files        map[string][]string
 		prompt       callbackFunc
 		wantSucc     []string
 		wantErr      error
@@ -42,6 +43,7 @@ func TestRunTests(t *testing.T) {
 				"test": {{Name: "test"}, {Name: "test2"}},
 			},
 			[]string{"test"},
+			map[string][]string{"test": {"tt"}},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n\ntest2:\ntest\n"},
 			nil,
@@ -57,6 +59,7 @@ func TestRunTests(t *testing.T) {
 				"test": {{Name: "test", Args: map[string]string{"ask": "&<ask>"}, Prompt: []string{"ask"}}},
 			},
 			[]string{"test"},
+			map[string][]string{},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\n-ask ask -logtostderr -target_name test -target_addr test -ca /certs/ca.crt -ca_key /certs/ca.key\n"},
 			nil,
@@ -73,6 +76,7 @@ func TestRunTests(t *testing.T) {
 				"test2": {{Name: "test2"}},
 			},
 			[]string{"test", "test2"},
+			map[string][]string{"test": {"tt"}},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n"},
 			nil,
@@ -88,6 +92,7 @@ func TestRunTests(t *testing.T) {
 				"test": {{Name: "test", Wants: "test"}},
 			},
 			[]string{"test"},
+			map[string][]string{},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n"},
 			nil,
@@ -103,6 +108,7 @@ func TestRunTests(t *testing.T) {
 				"test": {{Name: "test", Wants: "no"}},
 			},
 			[]string{"test"},
+			map[string][]string{},
 			func(name string) string { return name },
 			nil,
 			formatErr("test", "test", "test", errors.New("Wanted no in output"), 0, false, nil),
@@ -118,6 +124,7 @@ func TestRunTests(t *testing.T) {
 				"test": {{Name: "test", DoesntWant: "aaaa"}},
 			},
 			[]string{"test"},
+			map[string][]string{},
 			func(name string) string { return name },
 			[]string{"*test*:\ntest:\ntest\n"},
 			nil,
@@ -134,6 +141,7 @@ func TestRunTests(t *testing.T) {
 			viper.Set("targets.last_target", "test")
 			viper.Set("tests", test.tests)
 			viper.Set("order", test.order)
+			viper.Set("files", test.files)
 			RunContainer = test.runContainer
 			succ, err := RunTests(test.testNames, test.prompt, map[string]string{})
 			if diff := cmp.Diff(test.wantSucc, succ); diff != "" {


### PR DESCRIPTION
- Customisable chunk size for OS transfer in OS service (as previous default was too large and cause a transport error)

- Fixed `--files` in the tester and added a prompt if the user didnt provide the file in `--files`