### PR TITLE
Update gnoi_mockos/README.md

### DIFF
--- a/gnoi_mockos/README.md
+++ b/gnoi_mockos/README.md
@@ -19,5 +19,5 @@ go install github.com/google/gnxi/gnoi_mockos
   -version 1.10a \
   -size 100M \
   -activation_fail_message "I failed to activate" \
-  -incompatible false \
+  -incompatible=false \
 ```


### PR DESCRIPTION
This flag needs an = sign (to set to false) or just specified using -incompatible (to set to true)