### PR TITLE
TargetName is an Exported Flag

### DIFF
--- a/gnmi_capabilities/gnmi_capabilities.go
+++ b/gnmi_capabilities/gnmi_capabilities.go
@@ -33,14 +33,13 @@ import (
 
 var (
 	targetAddr = flag.String("target_addr", "localhost:9339", "The target address in the format of host:port")
-	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
 )
 
 func main() {
 	flag.Parse()
 
-	opts := credentials.ClientCredentials(*targetName)
+	opts := credentials.ClientCredentials()
 	conn, err := grpc.Dial(*targetAddr, opts...)
 	if err != nil {
 		log.Exitf("Dialing to %q failed: %v", *targetAddr, err)

--- a/gnmi_get/gnmi_get.go
+++ b/gnmi_get/gnmi_get.go
@@ -64,7 +64,6 @@ var (
 	pbPathFlags      arrayFlags
 	pbModelDataFlags arrayFlags
 	targetAddr       = flag.String("target_addr", "localhost:9339", "The target address in the format of host:port")
-	targetName       = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 	timeOut          = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
 	encodingName     = flag.String("encoding", "JSON_IETF", "value encoding format to be used")
 )
@@ -75,7 +74,7 @@ func main() {
 	flag.Var(&pbModelDataFlags, "model_data", "Data models to be used by the target in the format of 'name,organization,version'")
 	flag.Parse()
 
-	opts := credentials.ClientCredentials(*targetName)
+	opts := credentials.ClientCredentials()
 	conn, err := grpc.Dial(*targetAddr, opts...)
 	if err != nil {
 		log.Exitf("Dialing to %q failed: %v", *targetAddr, err)

--- a/gnmi_set/gnmi_set.go
+++ b/gnmi_set/gnmi_set.go
@@ -52,7 +52,6 @@ var (
 	replaceOpt arrayFlags
 	updateOpt  arrayFlags
 	targetAddr = flag.String("target_addr", "localhost:9339", "The target address in the format of host:port")
-	targetName = flag.String("target_name", "hostname.com", "The target name use to verify the hostname returned by TLS handshake")
 	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
 )
 
@@ -127,7 +126,7 @@ func main() {
 	flag.Var(&updateOpt, "update", "xpath:value pair to be updated. Value can be numeric, boolean, string, or IETF JSON file (. starts with '@').")
 	flag.Parse()
 
-	opts := credentials.ClientCredentials(*targetName)
+	opts := credentials.ClientCredentials()
 	conn, err := grpc.Dial(*targetAddr, opts...)
 	if err != nil {
 		log.Exitf("Dialing to %q failed: %v", *targetAddr, err)

--- a/gnmi_subscribe/gnmi_subscribe.go
+++ b/gnmi_subscribe/gnmi_subscribe.go
@@ -41,7 +41,7 @@ func (i *arrayFlags) Set(value string) error {
 }
 
 const (
-	defaultRequestTimeout = 10 * time.Second// This represents a value of 10 seconds and is used as a default RPC request timeout value.
+	defaultRequestTimeout = 10 * time.Second // This represents a value of 10 seconds and is used as a default RPC request timeout value.
 )
 
 var (
@@ -49,7 +49,6 @@ var (
 	xPathFlags        arrayFlags
 	pbPathFlags       arrayFlags
 	targetAddr        = flag.String("target_addr", ":9339", "The target address in the format of host:port")
-	targetName        = flag.String("target_name", "", "The target name used to verify the hostname returned by TLS handshake")
 	connectionTimeout = flag.Duration("timeout", defaultRequestTimeout, "The timeout for a request in seconds, 10 seconds by default, e.g 10s")
 	subscriptionOnce  = flag.Bool("once", false, "If true, the target sends values once off")
 	subscriptionPoll  = flag.Bool("poll", false, "If true, the target sends values on request")
@@ -65,7 +64,7 @@ func main() {
 	flag.Var(&pbPathFlags, "pbpath", "protobuf format path of the config node to be fetched")
 	flag.Parse()
 
-	opts := credentials.ClientCredentials(*targetName)
+	opts := credentials.ClientCredentials()
 	conn, err := grpc.Dial(*targetAddr, opts...)
 	if err != nil {
 		log.Fatalf("Dialing to %s failed: %v", *targetAddr, err)
@@ -156,7 +155,7 @@ func poll() {
 }
 
 func once() {
-	
+
 }
 
 func assembleSubscriptions(paths []*pb.Path) ([]*pb.Subscription, error) {

--- a/gnoi_cert/gnoi_cert.go
+++ b/gnoi_cert/gnoi_cert.go
@@ -41,7 +41,7 @@ var (
 	certID     = flag.String("cert_id", "", "Certificate Management certificate ID.")
 	certIDs    = flag.String("cert_ids", "", "Comma separated list of Certificate Management certificate IDs for revoke operation")
 	op         = flag.String("op", "get", "Certificate Management operation, one of: provision, install, rotate, get, revoke, check")
-	targetCN   = flag.String("target_name", "", "Common Name of the target.")
+	targetCN   = credUtils.TargetName
 	targetAddr = flag.String("target_addr", "localhost:9339", "The target address in the format of host:port")
 	timeOut    = flag.Duration("time_out", 5*time.Second, "Timeout for the operation, 5 seconds by default")
 	minKeySize = flag.Uint("min_key_size", 128, "Minimum key size")

--- a/gnoi_os/gnoi_os.go
+++ b/gnoi_os/gnoi_os.go
@@ -28,7 +28,6 @@ import (
 
 var (
 	targetAddr    = flag.String("target_addr", ":9339", "The target address in the format of host:port")
-	targetName    = flag.String("target_name", "", "The target name used to verify the hostname returned by TLS handshake")
 	version       = flag.String("version", "", "Version of the OS required when using the activate operation or being installed using the install operation")
 	osFile        = flag.String("os", "", "Path to the OS image for the install operation")
 	op            = flag.String("op", "", "OS service operation. Can be one of: install, activate, verify")
@@ -43,11 +42,7 @@ var (
 func main() {
 	flag.Parse()
 
-	if *targetName == "" {
-		flag.Usage()
-		log.Exit("-target_name must be specified")
-	}
-	opts := credentials.ClientCredentials(*targetName)
+	opts := credentials.ClientCredentials()
 	conn, err := grpc.Dial(*targetAddr, opts...)
 	if err != nil {
 		log.Exitf("Dialing to %s failed: %v", *targetAddr, err)

--- a/gnoi_reset/gnoi_reset.go
+++ b/gnoi_reset/gnoi_reset.go
@@ -32,7 +32,6 @@ import (
 
 var (
 	targetAddr = flag.String("target_addr", ":9339", "The target address in the format of host:port")
-	targetName = flag.String("target_name", "", "The target name used to verify the hostname returned by TLS handshake")
 	rollbackOs = flag.Bool("rollback_os", false, "Target must revert to factory OS")
 	zeroFill   = flag.Bool("zero_fill", false, "Target must overwrite persistent storage with zeroes")
 	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for ResetTarget operation, 10 seconds by default")
@@ -41,12 +40,7 @@ var (
 func main() {
 	flag.Parse()
 
-	if *targetName == "" || *targetAddr == "" {
-		flag.Usage()
-		log.Exit("-target_name and -target_addr must be specified")
-	}
-
-	opts := credentials.ClientCredentials(*targetName)
+	opts := credentials.ClientCredentials()
 	conn, err := grpc.Dial(*targetAddr, opts...)
 	if err != nil {
 		log.Exitf("Dialing to %s failed: %v", *targetAddr, err)

--- a/utils/credentials/credentials.go
+++ b/utils/credentials/credentials.go
@@ -38,6 +38,7 @@ var (
 	caKey          = flag.String("ca_key", "", "CA private key file.")
 	cert           = flag.String("cert", "", "Certificate file.")
 	key            = flag.String("key", "", "Private key file.")
+	TargetName     = flag.String("target_name", "", "The target name used to verify the hostname returned by TLS handshake") // TargetName is a flag containing the hostname verfified by TLS handshake
 	insecure       = flag.Bool("insecure", false, "Skip TLS validation.")
 	notls          = flag.Bool("notls", false, "Disable TLS validation. If true, no need to specify TLS related options.")
 	authorizedUser = userCredentials{}
@@ -130,7 +131,10 @@ func SetTargetName(name string) {
 }
 
 // ClientCredentials generates gRPC DialOptions for existing credentials.
-func ClientCredentials(server string) []grpc.DialOption {
+func ClientCredentials() []grpc.DialOption {
+	if *TargetName == "" {
+		log.Exit("Please provide a -target_name")
+	}
 	opts := []grpc.DialOption{}
 
 	if *notls {
@@ -141,7 +145,7 @@ func ClientCredentials(server string) []grpc.DialOption {
 			tlsConfig.InsecureSkipVerify = true
 		} else {
 			certificates, certPool := LoadCertificates()
-			tlsConfig.ServerName = server
+			tlsConfig.ServerName = *TargetName
 			tlsConfig.Certificates = certificates
 			tlsConfig.RootCAs = certPool
 		}


### PR DESCRIPTION
Closes #169 
TargetName is an exported flag in utils/credentials.go and the server arg is removed from the ClientCredentials functions