### PR TITLE
Fix RegEx for xpath leaf-list keys which include a "-" character.

### DIFF
--- a/gnmi_cli_py/py_gnmicli.py
+++ b/gnmi_cli_py/py_gnmicli.py
@@ -52,7 +52,7 @@ __version__ = '0.4'
 _RE_PATH_COMPONENT = re.compile(r'''
 ^
 (?P<pname>[^[]+)  # gNMI path name
-(\[(?P<key>\w+)   # gNMI path key
+(\[(?P<key>\w\D+)   # gNMI path key
 =
 (?P<value>.*)    # gNMI path value
 \])?$


### PR DESCRIPTION
For example:
/bgp/neighbors/neighbor[neighbor-address=30.1.1.1]/config/neighbor-address