### PR TITLE
allow loading multiple CAs into bundle

### DIFF
--- a/gnoi_cert/gnoi_cert.go
+++ b/gnoi_cert/gnoi_cert.go
@@ -50,8 +50,10 @@ var (
 	org        = flag.String("organization", "OpenConfig", "Organization in CSR parameters")
 	orgUnit    = flag.String("organizational_unit", "gNxI", "Organizational unit in CSR parameters")
 	ipAddress  = flag.String("ip_address", "127.0.0.1", "IP address in CSR parameters")
+	otherCAs   = flag.String("other_cas", "", "Other CA certificate files that will get sent in the CA bundle but are not used to establish a connection or sign the CSR. Only filename prefix required. Suffixes assumed to be .pem and .key")
 
 	caEnt     *entity.Entity
+	caBundle  []*x509.Certificate
 	ctx       context.Context
 	cancel    func()
 	dial      = grpc.Dial
@@ -74,14 +76,17 @@ func main() {
 	switch *op {
 	case "provision":
 		caEnt = credUtils.GetCAEntity()
+		loadCABundle()
 		certIDCheck()
 		provision()
 	case "install":
 		caEnt = credUtils.GetCAEntity()
+		loadCABundle()
 		certIDCheck()
 		install()
 	case "rotate":
 		caEnt = credUtils.GetCAEntity()
+		loadCABundle()
 		certIDCheck()
 		rotate()
 	case "revoke":
@@ -99,6 +104,22 @@ func certIDCheck() {
 	if *certID == "" {
 		log.Exit("Must set a certificate ID with -cert_id.")
 	}
+}
+
+func loadCABundle() {
+	if *otherCAs != "" {
+		otherCAFileNames := strings.FieldsFunc(*otherCAs, func(r rune) bool { return r == ',' })
+		var ent *entity.Entity
+		var err error
+		for _, s := range otherCAFileNames {
+			ent, err = entity.FromFile(s+".pem", s+".key")
+			if err != nil {
+				log.Exitf("Cannot read files %s.pem and %s.key: %v", s, s, err)
+			}
+			caBundle = append(caBundle, ent.Certificate.Leaf)
+		}
+	}
+	caBundle = append(caBundle, caEnt.Certificate.Leaf)
 }
 
 // gnoiEncrypted creates an encrypted TLS connection to the target.
@@ -158,7 +179,7 @@ func provision() {
 	defer conn.Close()
 	pkiName := pkix.Name{CommonName: *targetCN, Organization: []string{*org}, OrganizationalUnit: []string{*orgUnit}, Country: []string{*country}, Province: []string{*state}}
 
-	if err := client.Install(ctx, *certID, uint32(*minKeySize), pkiName, *ipAddress, signer, []*x509.Certificate{caEnt.Certificate.Leaf}); err != nil {
+	if err := client.Install(ctx, *certID, uint32(*minKeySize), pkiName, *ipAddress, signer, caBundle); err != nil {
 		log.Exit("Failed Install:", err)
 	}
 	log.Info("Install success")
@@ -170,7 +191,7 @@ func install() {
 	defer conn.Close()
 	pkiName := pkix.Name{CommonName: *targetCN, Organization: []string{*org}, OrganizationalUnit: []string{*orgUnit}, Country: []string{*country}, Province: []string{*state}}
 
-	if err := client.Install(ctx, *certID, uint32(*minKeySize), pkiName, *ipAddress, signer, []*x509.Certificate{caEnt.Certificate.Leaf}); err != nil {
+	if err := client.Install(ctx, *certID, uint32(*minKeySize), pkiName, *ipAddress, signer, caBundle); err != nil {
 		log.Exit("Failed Install:", err)
 	}
 	log.Info("Install success")
@@ -182,7 +203,7 @@ func rotate() {
 	defer conn.Close()
 	pkiName := pkix.Name{CommonName: *targetCN, Organization: []string{*org}, OrganizationalUnit: []string{*orgUnit}, Country: []string{*country}, Province: []string{*state}}
 
-	if err := client.Rotate(ctx, *certID, uint32(*minKeySize), pkiName, *ipAddress, signer, []*x509.Certificate{caEnt.Certificate.Leaf}, func() error { return nil }); err != nil {
+	if err := client.Rotate(ctx, *certID, uint32(*minKeySize), pkiName, *ipAddress, signer, caBundle, func() error { return nil }); err != nil {
 		log.Exit("Failed Rotate:", err)
 	}
 	log.Info("Rotate success")

--- a/gnoi_cert/gnoi_cert.go
+++ b/gnoi_cert/gnoi_cert.go
@@ -109,10 +109,8 @@ func certIDCheck() {
 func loadCABundle() {
 	if *otherCAs != "" {
 		otherCAFileNames := strings.FieldsFunc(*otherCAs, func(r rune) bool { return r == ',' })
-		var ent *entity.Entity
-		var err error
 		for _, s := range otherCAFileNames {
-			ent, err = entity.FromFile(s+".pem", s+".key")
+			ent, err := entity.FromFile(s+".pem", s+".key")
 			if err != nil {
 				log.Exitf("Cannot read files %s.pem and %s.key: %v", s, s, err)
 			}


### PR DESCRIPTION
The current client doesn't allow loading multiple certificates at once in a single install/rotate operation. 

New argument: `other_cas`
Comma separated list of filename prefixes that the client will use to the load the associated `.pem` and `.key` files

Usage:
```
./gnoi_cert -target_addr localhost:9339 -target_name 10.85.68.161 -logtostderr -ca device_rootCA.pem -ca_key device_rootCA.key -op provision -cert_id gnoi_demo \
-other_cas client_intermediateCA_B,client_intermediateCA_C,client_rootCA_B,client_rootCA_C,device_intermediateCA,device_rootCA -ip_address 10.85.68.161 -organization gnoi_dem -time_out 1m
```