### PR TITLE
Override username and password instead of appending them.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-/.project
-tags
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.project
+tags
+*.swp

--- a/utils/credentials/credentials.go
+++ b/utils/credentials/credentials.go
@@ -161,11 +161,19 @@ func ClientCredentials() []grpc.DialOption {
 }
 
 // AttachToContext attaches credentials to a context.
+// If there are existing credentials, it overrides their values.
 func AttachToContext(ctx context.Context) context.Context {
 	if authorizedUser.username == "" {
 		return ctx
 	}
-	return metadata.AppendToOutgoingContext(ctx, usernameKey, authorizedUser.username, passwordKey, authorizedUser.password)
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+	}
+	md.Set(usernameKey, authorizedUser.username)
+	md.Set(passwordKey, authorizedUser.password)
+
+	return metadata.NewOutgoingContext(ctx, md)
 }
 
 // GetCAEntity gets a CA entity from a CA file and private key.

--- a/utils/credentials/credentials_test.go
+++ b/utils/credentials/credentials_test.go
@@ -1,0 +1,26 @@
+package credentials
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestTwiceAttachToContext(t *testing.T) {
+	authorizedUser = userCredentials{
+		username: "foo",
+		password: "bar",
+	}
+	ctx := AttachToContext(context.Background())
+	ctx = AttachToContext(ctx)
+	got, _ := metadata.FromOutgoingContext(ctx)
+	want := metadata.MD{
+		"username": []string{"foo"},
+		"password": []string{"bar"},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Fatalf("(-got, +want):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This ensures that the same context being called twice by `AttachToContext` doesn't replicate the username and password metadata.

Possibly addresses #271.