### PR TITLE
oc_config_validate prints and reports the OC models versions used.

### DIFF
--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -165,6 +165,8 @@ In case of errors, use the `--debug` flag to help understand the underlying TLS 
 
 The model bindings are used in tests that validate the gNMI JSON payloads against the expected OpenConfig model. See [docs/tests](docs/tests.md) for more details.
 
+Run `python3 -m oc_config_validate -models` to get a list of the versions (revisions) of the OC models used. These are also added to the results file.
+
 ## Copyright
 
 Contains code from https://github.com/google/gnxi/tree/master/gnmi_cli_py and

--- a/oc_config_validate/demo/results.json
+++ b/oc_config_validate/demo/results.json
@@ -1,5 +1,17 @@
 {
   "test_target": "localhost:9339",
+  "oc_models": [
+    "openconfig-interfaces@2021-04-06",
+    "openconfig-if-ip@2019-01-08",
+    "openconfig-access-points@2020-04-28",
+    "openconfig-ap-interfaces@2020-03-24",
+    "openconfig-ap-manager@2020-06-30",
+    "openconfig-system@2021-07-20",
+    "openconfig-aaa@2020-07-30",
+    "openconfig-local-routing@2020-03-24",
+    "openconfig-bgp@2021-06-16",
+    "openconfig-lldp@2018-11-21"
+  ],
   "description": "Example of test profile for oc_config_validator",
   "labels": [
     "FOO",

--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -23,7 +23,8 @@ from typing import Any, Dict, Optional
 
 import yaml
 
-from oc_config_validate import context, formatter, runner, target, testbase
+from oc_config_validate import (context, formatter, runner, schema, target,
+                                testbase)
 
 __version__ = "1.0.0"
 
@@ -115,6 +116,9 @@ def createArgsParser() -> argparse.ArgumentParser:
         "-v", "--version", help="Print program version", action="store_true")
     parser.add_argument(
         "-V", "--verbose", help="Enable gRPC debugging and extra logging",
+        action="store_true")
+    parser.add_argument(
+        "-models", "--oc_models_versions", help="Print OC models versions",
         action="store_true")
     parser.add_argument(
         "--no_tls", help="gRPC insecure mode", action="store_true")
@@ -254,9 +258,14 @@ def main():  # noqa
     """Executes this library."""
     argparser = createArgsParser()
     args = vars(argparser.parse_args())
+
     if args["version"]:
         print(__version__)
         sys.exit()
+    if args["oc_models_versions"]:
+        print(schema.getOcModelsVersions())
+        sys.exit()
+
     if args["verbose"]:
         # os.environ["GRPC_TRACE"] = "all"
         os.environ["GRPC_VERBOSITY"] = "DEBUG"

--- a/oc_config_validate/oc_config_validate/models/versions
+++ b/oc_config_validate/oc_config_validate/models/versions
@@ -1,0 +1,10 @@
+openconfig-interfaces@2021-04-06
+openconfig-if-ip@2019-01-08
+openconfig-access-points@2020-04-28
+openconfig-ap-interfaces@2020-03-24
+openconfig-ap-manager@2020-06-30
+openconfig-system@2021-07-20
+openconfig-aaa@2020-07-30
+openconfig-local-routing@2020-03-24
+openconfig-bgp@2021-06-16
+openconfig-lldp@2018-11-21

--- a/oc_config_validate/oc_config_validate/schema.py
+++ b/oc_config_validate/oc_config_validate/schema.py
@@ -15,9 +15,10 @@ limitations under the License.
 """
 
 import json
+import os
 import re
 from inspect import isclass
-from typing import Union
+from typing import List, Union
 
 from pyangbind.lib.base import PybindBase
 from pyangbind.lib.serialise import pybindJSONDecoder
@@ -104,3 +105,15 @@ def fixSubifIndex(json_value: dict):
         'subinterface'][0]['index']
     json_value['openconfig-interfaces:subinterfaces']['subinterface'][0][
         'index'] = int(index)
+
+
+def getOcModelsVersions() -> List[str]:
+    """Returns a list of the OC models versions used.
+
+     Returns an empty list if unable to read the models/versions file.
+     """
+    versions_file = os.path.join(os.path.dirname(models.__file__), "versions")
+    if os.path.isfile(versions_file):
+        with open(versions_file) as f:
+            return [line.strip() for line in f]
+    return []

--- a/oc_config_validate/oc_config_validate/testbase.py
+++ b/oc_config_validate/oc_config_validate/testbase.py
@@ -399,6 +399,7 @@ class TestRun():
 
     def __init__(self, tgt: str, ctx: context.TestContext):
         self.test_target = tgt
+        self.oc_models = schema.getOcModelsVersions()
         if ctx.description:
             self.description = ctx.description
         if ctx.labels:

--- a/oc_config_validate/oc_config_validate/update_models.sh
+++ b/oc_config_validate/oc_config_validate/update_models.sh
@@ -27,19 +27,23 @@ git clone --depth 1 https://github.com/openconfig/public.git "$MODELS_FOLDER/pub
 
 PYBINDPLUGIN=$(/usr/bin/env python -c 'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))')
 
-pyang --plugindir $PYBINDPLUGIN -f pybind --path "$MODELS_FOLDER/" \
-  --split-class-dir "$MODELS_FOLDER/"  \
-  "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-interfaces.yang"  \
-  "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-if-ip.yang" \
-  "${MODELS_FOLDER}/public/release/models/wifi/openconfig-access-points.yang" \
-  "${MODELS_FOLDER}/public/release/models/wifi/openconfig-ap-interfaces.yang" \
-  "${MODELS_FOLDER}/public/release/models/wifi/openconfig-ap-manager.yang" \
-  "${MODELS_FOLDER}/public/release/models/system/openconfig-system.yang" \
-  "${MODELS_FOLDER}/public/release/models/system/openconfig-aaa.yang" \
-  "${MODELS_FOLDER}/public/release/models/local-routing/openconfig-local-routing.yang" \
-  "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp.yang" \
-  "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp-global.yang" \
-  "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp-neighbor.yang" \
-  "${MODELS_FOLDER}/public/release/models/lldp/openconfig-lldp.yang"
+MODELS=( "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-interfaces.yang" \
+          "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-if-ip.yang" \
+          "${MODELS_FOLDER}/public/release/models/wifi/openconfig-access-points.yang" \
+          "${MODELS_FOLDER}/public/release/models/wifi/openconfig-ap-interfaces.yang" \
+          "${MODELS_FOLDER}/public/release/models/wifi/openconfig-ap-manager.yang" \
+          "${MODELS_FOLDER}/public/release/models/system/openconfig-system.yang" \
+          "${MODELS_FOLDER}/public/release/models/system/openconfig-aaa.yang" \
+          "${MODELS_FOLDER}/public/release/models/local-routing/openconfig-local-routing.yang" \
+          "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp.yang" \
+          "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp-global.yang" \
+          "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp-neighbor.yang" \
+          "${MODELS_FOLDER}/public/release/models/lldp/openconfig-lldp.yang" )
+
+pyang --plugindir $PYBINDPLUGIN -f pybind  --path "$MODELS_FOLDER/" \
+  --split-class-dir "$MODELS_FOLDER/" ${MODELS[@]}
+
+pyang --plugindir $PYBINDPLUGIN -f name --name-print-revision \
+  --path "$MODELS_FOLDER/" --output "$MODELS_FOLDER/versions" ${MODELS[@]}
 
 rm -rf "$MODELS_FOLDER/public"


### PR DESCRIPTION
It is important to know against which OC models were the JSON blobs in tests compared.

When binding the OC models, a file is written with the versions of the models. This file is used to print the OC models versions and also added to the results.