### PR TITLE
Multiple initial configurations

### DIFF
--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -49,12 +49,14 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
 
 ### Use
 
- 1. Prepare the initial OpenConfig configuration for your device, in JSON format.
+ 1. Prepare the initial OpenConfig configuration(s) for your device, in JSON format.
 
-    This configuration will be applied to the device before any other operation,
+    This configuration(s) will be applied to the device before any other operation,
     to bring it to a known initial state.
 
-    The initial configuration is sent in a single gNMI Set Update message to the indicated xpath. 
+    Each initial configuration file is sent in a single gNMI Set Update message to the indicated xpath.
+
+    All initial configurations found on the test file and on the command line are applied, sequentially.
 
  1. Then, write your OpenConfig configuration tests, in YAML format.
  
@@ -65,11 +67,12 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
  1. Finally, validate your configurations against a gNMI target using:
  
 ```
-    python3 -m oc_config_validate --target {$HOSTNAME}:{$PORT} \
-       [--username {$USERNAME}] -[-password {$PASSWORD}] \
-       [--tls_host_override ${TLS_HOSTNAME} | --no_tls ] \
-       -tests ${TESTS} -results ${RESULTS} 
-       [-init ${INIT_CONFIG_FILE} -xpath ${INIT_CONFIG_XPATH}]
+    python3 -m oc_config_validate --target HOSTNAME:PORT \
+       -tests TESTS_FILE -results RESULTS_FILE \
+       [--username USERNAME] [--password PASSWORD] \
+       [--tls_host_override TLS_HOSTNAME | --no_tls ] \
+       [-init INIT_CONFIG_FILE -xpath INIT_CONFIG_XPATH] \
+       [--verbose] [--log_gnmi] [--stop_on_error]
 ```
     
     For an example:
@@ -77,9 +80,10 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
 ```
     python3 -m oc_config_validate --target localhost:9339 \
        --username gnmi --password gnmi \
-       --tls_host_override target.com
-       -tests tests/example.yaml -results results/example.json
-       -init init_configs/example.json -xpath "/system/"
+       --tls_host_override target.com \
+       -tests tests/example.yaml -results results/example.json \
+       -init init_configs/example.json -xpath "/system/" \
+       --log_gnmi
 ```
 
  1. Expect an output similar to:

--- a/oc_config_validate/demo/tests.yaml
+++ b/oc_config_validate/demo/tests.yaml
@@ -1,10 +1,16 @@
 !TestContext
 description: Example of test profile for oc_config_validator
+
 labels:
 - FOO
 - BAR
-tests:
 
+init_configs:
+- !InitConfig
+  filename: init_config.json
+  xpath: /system/config
+
+tests:
 - !TestCase
   name: "Get System Config"
   class_name: get.Get

--- a/oc_config_validate/docs/tests.md
+++ b/oc_config_validate/docs/tests.md
@@ -4,12 +4,23 @@
 
 ```
 !TestContext
+
 # Informative text about this test run.
 description: [:string]
+
 # Optional list of text labels, passed to the Results. Can be used for tagging and filtering. 
 labels: 
 - [:string]
 - [:string]
+
+# Optional list of initial configurations and xpaths to apply before the tests.
+init_configs:
+- !InitConfig
+  # Path to the initial configuration JSON file.
+  filename: [:string]
+  #Xpath where to send a gNMI Set Update messages with the configuration.
+  xpath: [:string]
+  
 # List of Tests to run
 tests: 
 - !TestCase

--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -14,12 +14,11 @@ limitations under the License.
 
 """
 import argparse
-import json
 import logging
 import os
 import sys
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import yaml
 
@@ -177,6 +176,12 @@ def validateArgs(args: Dict[str, Any]) -> bool:  # noqa
                                                  False):
         return False
 
+    # Provide init_config file and xpath
+    if bool(args["init_config_file"]) ^ bool(args["init_config_xpath"]):
+        logging.error(
+            "Initial configuration file and xpath are both needed.")
+        return False
+
     # Either TLS or not
     if any([args[arg] for arg in [
             "private_key", "cert_chain", "root_ca_cert",
@@ -200,56 +205,6 @@ def validateArgs(args: Dict[str, Any]) -> bool:  # noqa
     return True
 
 
-def loadTestContextFromFile(file_path) -> Optional[context.TestContext]:
-    """Loads the tests description file and returns a TestContext.
-
-     Args:
-        file_path: Path to a YAML file with test profile.
-
-     Returns:
-        A TestContext object with all test information, or None if
-           error.
-
-     Raises:
-        IOError: An error occurred while trying to read the file.
-        YAMLError: An error occurred while trying to parse the YAML
-           file.
-     """
-    ctx = None
-    try:
-        with open(file_path, encoding="utf8") as raw_profile_data:
-            ctx = context.fromFile(raw_profile_data)
-    except IOError as io_error:
-        logging.error("Unable to read %s: %s", file_path, io_error)
-        return None
-    except yaml.YAMLError as yaml_error:
-        logging.error("Unable to parse YAML file %s: %s", file_path,
-                      yaml_error)
-        return None
-    return ctx
-
-
-def setConfigFile(file_path: str, xpath: str,
-                  tgt: target.TestTarget) -> bool:
-    """Applies the JSON-formated configuration to the target.
-
-    Args:
-        file_path: Path to a JSON file with the configuration to apply.
-        xpath: gNMI xpath where to apply the configuration.
-        tgt: Target to configure.
-
-    Returns:
-        True if the configuration was applied successfully.
-    """
-    try:
-        tgt.gNMISetConfigFile(file_path, xpath)
-    except (IOError, json.JSONDecodeError, target.BaseError) as err:
-        logging.error("Unable to set configuration '%s' via gNMI: %s",
-                      file_path, err)
-        return False
-    return True
-
-
 def main():  # noqa
     """Executes this library."""
     argparser = createArgsParser()
@@ -268,9 +223,14 @@ def main():  # noqa
     if not validateArgs(args):
         sys.exit(1)
 
-    ctx = loadTestContextFromFile(args["tests_file"])
-    if ctx is None:
-        sys.exit(1)
+    try:
+        ctx = context.fromFile(args["tests_file"])
+    except IOError as io_error:
+        sys.exit("Unable to read %s: %s", args["tests_file"], io_error)
+    except yaml.YAMLError as yaml_error:
+        sys.exit("Unable to parse YAML file %s: %s", args["tests_file"],
+                 yaml_error)
+
     logging.info("Read tests file '%s': %d tests to run",
                  args["tests_file"], len(ctx.tests))
 
@@ -293,13 +253,11 @@ def main():  # noqa
 
     # Apply initial configuration
     if args["init_config_file"]:
-        if not setConfigFile(args["init_config_file"],
-                             args["init_config_xpath"],
-                             tgt):
-            logging.error("Unable to set the initial configuration")
-            sys.exit(1)
-        logging.info("Initial OpenConfig '%s' applied on gNMI xpath %s",
-                     args["init_config_file"], args["init_config_xpath"])
+        ctx.init_configs.append(context.InitConfig(args["init_config_file"],
+                                                   args["init_config_xpath"]))
+    if not runner.setInitConfigs(ctx, tgt,
+                                 stop_on_error=args["stop_on_error"]):
+        sys.exit(1)
 
     start_t = time.time()
     results = runner.runTests(ctx, tgt, stop_on_error=args["stop_on_error"])

--- a/oc_config_validate/oc_config_validate/context.py
+++ b/oc_config_validate/oc_config_validate/context.py
@@ -22,12 +22,14 @@ class TestContext(yaml.YAMLObject):
 
     yaml_loader = yaml.SafeLoader
     yaml_tag = u'!TestContext'
+    init_configs = []
     labels = []
     tests = []
     description = ""
 
-    def __init__(self, description, labels, tests):
+    def __init__(self, description, init_configs, labels, tests):
         self.description = description
+        self.init_configs = init_configs
         self.labels = labels
         self.tests = tests
 
@@ -52,12 +54,31 @@ class TestCase(yaml.YAMLObject):
                 (self.name, self.class_name, self.args))
 
 
-def fromFile(yaml_stream):
+class InitConfig(yaml.YAMLObject):
+    """Object parsed from the TestContext YAML file."""
+
+    yaml_loader = yaml.SafeLoader
+    yaml_tag = u'!InitConfig'
+
+    def __init__(self, filename, xpath):
+        self.filename = filename
+        self.xpath = xpath
+
+    def __repr__(self):
+        return ('InitConfig(filename=%r, xpath=%r)' %
+                (self.filename, self.xpath))
+
+
+def fromFile(file_path) -> TestContext:
     """Create a TestContext object from a YAML file.
 
     Args:
-        yaml_stream: A file-like object that supports the .read() method.
+        file_path: Path to a YAML file with test profile.
 
+    Raises:
+        IOError: An error occurred while trying to read the file.
+        YAMLError: An error occurred while trying to parse the YAML
+           file.
     """
-    context = yaml.safe_load(yaml_stream)
-    return context
+    with open(file_path, encoding="utf8") as raw_profile_data:
+        return yaml.safe_load(raw_profile_data)

--- a/oc_config_validate/oc_config_validate/testbase.py
+++ b/oc_config_validate/oc_config_validate/testbase.py
@@ -21,7 +21,6 @@ import unittest
 from functools import wraps
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import grpc
 from pyangbind.lib import pybindJSON
 
 from oc_config_validate import context, schema, target
@@ -125,7 +124,7 @@ class TestCase(unittest.case.TestCase):
         """
         try:
             resp = self.test_target.gNMIGet(xpath)
-        except grpc._channel._InactiveRpcError as err:
+        except target.RpcError as err:
             if LOG_GNMI:
                 self.log("gNMI Get(%s) => ", xpath)
             self.log("gRCP Error: %s", err)
@@ -149,7 +148,7 @@ class TestCase(unittest.case.TestCase):
             self.log("gNMI Set Update(%s) => %s", xpath, value)
         try:
             self.test_target.gNMISetUpdate(xpath, value)
-        except grpc._channel._InactiveRpcError as err:
+        except target.RpcError as err:
             self.log("gRCP Error: %s", err)
             return False
         return True
@@ -167,7 +166,7 @@ class TestCase(unittest.case.TestCase):
             self.log("gNMI Set Delete(%s) =>", xpath)
         try:
             self.test_target.gNMISetDelete(xpath)
-        except grpc._channel._InactiveRpcError as err:
+        except target.RpcError as err:
             self.log("gRCP Error: %s", err)
             return False
         return True
@@ -311,7 +310,7 @@ class TestResult(unittest.TestResult):
             self.log_message, self._exc_info_to_string(err, test))
         self.errors.append((test, log))
         self._mirrorOutput = True
-        logging.info("%s - ERR:\n%s", test, log)
+        logging.error("%s - ERR:\n%s", test, log)
 
     @failfast
     def addFailure(self, test: TestCase, err):
@@ -320,13 +319,13 @@ class TestResult(unittest.TestResult):
             self.log_message, self._exc_info_to_string(err, test))
         self.failures.append((test, log))
         self._mirrorOutput = True
-        logging.info("%s - FAIL:\n%s", test, log)
+        logging.error("%s - FAIL:\n%s", test, log)
 
     def addSuccess(self, test: TestCase):
         """Store the log messages for every successful test."""
         self.successes.append((test, self.log_message))
         logging.debug("%s - PASS:\n%s", test, self.log_message)
-        
+
     def addSkip(self, test: TestCase, reason: str):
         """Override parent addFailure to support logging."""
         self.skipped.append((test, reason))


### PR DESCRIPTION
There can be none, one or more initial configurations to set before a test. These are pairs of xpath and json file, and they can be defined in the test YAML file and also as command argument.

In this process, some code used go rearranged, mainly out of the main function into other modules.