### PR TITLE
Define Target in test file, and override options with command arguments

### DIFF
--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -69,8 +69,8 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
  1. Finally, validate your configurations against a gNMI target using:
  
 ```
-    python3 -m oc_config_validate --target HOSTNAME:PORT \
-       -tests TESTS_FILE -results RESULTS_FILE \
+    python3 -m oc_config_validate -tests TESTS_FILE -results RESULTS_FILE \
+       [--target HOSTNAME:PORT] \
        [--username USERNAME] [--password PASSWORD] \
        [--tls_host_override TLS_HOSTNAME | --no_tls ] \
        [-init INIT_CONFIG_FILE -xpath INIT_CONFIG_XPATH] \
@@ -150,15 +150,15 @@ By default, *oc_config_validate* will use TLS for the gNMI connection, will
 validate the hostname presented by the Target in its certificate and will fetch
 the Root CA certificate from the Target.
 
- *  Use the `--tls_host_override` flag to provide the hostname value present
+ *  Use the `tls_host_override` option to provide the hostname value present
     in the Target's certificate.
- *  Use the `--root_cat` flag to provide the Root CA certificate file to use.
- *  Use the `-key` and `-cert` flags to provide the TLS key and certificate 
+ *  Use the `root_ca_cert` option to provide the Root CA certificate file to use.
+ *  Use the `private_key` and `cert_chain` options to provide the TLS key and certificate 
     files that the client will present to the Target.
 
 In case of errors, use the `--debug` flag to help understand the underlying TLS issue, if any.
 
- > With case, use the `--no_tls` flag not to use TLS for the gNMI connection. 
+ > With care, use the `no_tls` option not to use TLS for the gNMI connection. 
  >
  > Warning: All communication will be in plain text.
 

--- a/oc_config_validate/demo/run_demo.sh
+++ b/oc_config_validate/demo/run_demo.sh
@@ -41,12 +41,12 @@ stop_gnmi_target() {
 
 # start_oc_config_validate <gnmi_port>
 start_oc_config_validate() {
-    OPTS="--tls_host_override target.com"
+    OPTS=""
     if [[ "$NO_TLS" -eq 1 ]]; then
         OPTS="--no_tls"
     fi
     if [[ "$ROOT_CA" -eq 1 ]]; then
-        OPTS="$OPTS -ca $BASEDIR/certs/ca.crt"
+        OPTS="-ca $BASEDIR/certs/ca.crt"
     fi
     if [[ "$CLIENT_TLS" -eq 1 ]]; then
         OPTS="$OPTS -key $BASEDIR/certs/client.key -cert $BASEDIR/certs/client.crt"

--- a/oc_config_validate/demo/tests.yaml
+++ b/oc_config_validate/demo/tests.yaml
@@ -5,6 +5,11 @@ labels:
 - FOO
 - BAR
 
+target:
+  !Target
+  target: "localhost:8080"
+  tls_host_override: "target.com"
+
 init_configs:
 - !InitConfig
   filename: init_config.json

--- a/oc_config_validate/docs/tests.md
+++ b/oc_config_validate/docs/tests.md
@@ -13,6 +13,18 @@ labels:
 - [:string]
 - [:string]
 
+# Target to connect to. Overridden by command arguments
+target:
+  !Target
+  target: [:string]  # As "hostname:port"
+  username: [:string]
+  password: [:string]  # Attention, this is clear text.
+  no_tls: [:bool]
+  private_key: [:string]  # Path to file
+  cert_chain: [:string]  # Path to file
+  root_ca_cert: [:string]  # Path to file
+  tls_host_override: [:string]
+
 # Optional list of initial configurations and xpaths to apply before the tests.
 init_configs:
 - !InitConfig

--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -141,72 +141,36 @@ def createArgsParser() -> argparse.ArgumentParser:
     return parser
 
 
-def validateArgs(args: Dict[str, Any]) -> bool:  # noqa
+def validateArgs(args: Dict[str, Any]):
     """Returns True if the arguments are valid.
 
-    To run tests:
-     * A valid target is needed, as HOSTNAME:PORT.
-     * All readable tests, results and initial config files are needed.
-     * --notls and TLS arguments are exclusive.
+     Raises:
+       ValueError if any argument is invalid.
+       IOError is unable to open a file given in argument.
 
     """
 
-    def isTarget(tgt: str) -> bool:
-        parts = tgt.split(":")
-        return len(parts) == 2 and bool(parts[0]) and parts[1].isdigit()
-
-    def isFileOK(filename: str, writable: bool = False) -> bool:
+    def isFileOK(filename: str, writable: bool = False):
         try:
             file = open(filename, "w+" if writable else "r", encoding="utf8")
             file.close()
         except IOError as io_error:
             logging.error("Unable to open %s: %s", filename, io_error)
-            return False
-        return True
+            raise
 
     # Mandatory args for tests
-    if not args["target"] or not isTarget(args["target"]):
-        logging.error("Needed valid --target HOSTNAME:PORT argument")
-        return False
-
     for arg, write in [("tests_file", False), ("results_file", True)]:
         if not args[arg]:
-            logging.error("Needed --%s file", arg)
-            return False
-        if not isFileOK(args[arg], write):
-            return False
+            raise ValueError("Needed --%s file" % arg)
+        isFileOK(args[arg], write)
 
-    if args["init_config_file"] and not isFileOK(args["init_config_file"],
-                                                 False):
-        return False
-
-    # Provide init_config file and xpath
-    if bool(args["init_config_file"]) ^ bool(args["init_config_xpath"]):
-        logging.error(
-            "Initial configuration file and xpath are both needed.")
-        return False
-
-    # Either TLS or not
-    if any([args[arg] for arg in [
-            "private_key", "cert_chain", "root_ca_cert",
-            "tls_host_override"]]) and args["no_tls"]:
-        logging.error(
-            "TLS arguments and --notls option are mutually exclusive.")
-        return False
-
-    # If using client certificates for TLS, provide key and cert
-    if bool(args["private_key"]) ^ bool(args["cert_chain"]):
-        logging.error(
-            "TLS arguments -private_key and -cert_chain are both needed.")
-        return False
+    if args["init_config_file"]:
+        isFileOK(args["init_config_file"], False)
 
     # Output format supported
     if (args["format"] and
             args["format"].lower() not in formatter.SUPPORTED_FORMATS):
-        logging.error("Output format %s is not supported.")
-        return False
-
-    return True
+        raise ValueError("Output format %s is not supported.")
 
 
 def main():  # noqa
@@ -224,39 +188,43 @@ def main():  # noqa
     if args["verbose"]:
         # os.environ["GRPC_TRACE"] = "all"
         os.environ["GRPC_VERBOSITY"] = "DEBUG"
-
     logging.basicConfig(
         level=logging.DEBUG if args["verbose"] else logging.INFO,
         format=LOGGING_FORMAT)
 
-    if not validateArgs(args):
-        sys.exit(1)
+    try:
+        validateArgs(args)
+    except (IOError, ValueError) as error:
+        sys.exit("Invalid arguments: %s" % error)
+
+    if args["log_gnmi"]:
+        testbase.LOG_GNMI = args["log_gnmi"]
 
     try:
         ctx = context.fromFile(args["tests_file"])
     except IOError as io_error:
-        sys.exit("Unable to read %s: %s", args["tests_file"], io_error)
+        sys.exit("Unable to read %s: %s" % (args["tests_file"], io_error))
     except yaml.YAMLError as yaml_error:
-        sys.exit("Unable to parse YAML file %s: %s", args["tests_file"],
-                 yaml_error)
+        sys.exit("Unable to parse YAML file %s: %s" % (args["tests_file"],
+                 yaml_error))
 
     logging.info("Read tests file '%s': %d tests to run",
                  args["tests_file"], len(ctx.tests))
 
-    tgt = target.TestTarget(args["target"])
-    tgt.setCredentials(args["username"], args["password"])
-    if args["no_tls"]:
-        tgt.notls = True
-    else:
-        logging.info("Using TLS for gNMI connection")
-        tgt.setCertificates(key=args["private_key"],
-                            cert=args["cert_chain"],
-                            root_ca=args["root_ca_cert"])
-        if args["tls_host_override"]:
-            tgt.host_tls_override = args["tls_host_override"]
+    if not ctx.target:
+        ctx.target = context.Target()
 
-    if args["log_gnmi"]:
-        testbase.LOG_GNMI = args["log_gnmi"]
+    # Override Target options
+    for arg in ["target", "username", "password", "no_tls", "private_key",
+                "cert_chain", "root_ca_cert", "tls_host_override"]:
+        if args[arg]:
+            setattr(ctx.target, arg, args[arg])
+
+    tgt = target.TestTarget(ctx.target)
+    try: 
+        tgt.validate()
+    except ValueError as error:
+        sys.exit("Invalid Target: %s" % error)
 
     logging.info("Testing gNMI Target %s.", args["target"])
 

--- a/oc_config_validate/oc_config_validate/context.py
+++ b/oc_config_validate/oc_config_validate/context.py
@@ -24,13 +24,15 @@ class TestContext(yaml.YAMLObject):
     yaml_tag = u'!TestContext'
     init_configs = []
     labels = []
+    target = None
     tests = []
     description = ""
 
-    def __init__(self, description, init_configs, labels, tests):
+    def __init__(self, description, init_configs, labels, target, tests):
         self.description = description
         self.init_configs = init_configs
         self.labels = labels
+        self.target = target
         self.tests = tests
 
     def __repr__(self):
@@ -67,6 +69,25 @@ class InitConfig(yaml.YAMLObject):
     def __repr__(self):
         return ('InitConfig(filename=%r, xpath=%r)' %
                 (self.filename, self.xpath))
+
+
+class Target(yaml.YAMLObject):
+    """Object parsed from the TestContext YAML file."""
+
+    yaml_loader = yaml.SafeLoader
+    yaml_tag = u'!Target'
+
+    target = ""
+    username = ""
+    password = ""
+    private_key = ""
+    root_ca_cert = ""
+    cert_chain = ""
+    no_tls = False
+    tls_host_override = ""
+
+    def __repr__(self):
+        return 'Target(target=%r, no_tls=%r)' % (self.target, self.no_tls)
 
 
 def fromFile(file_path) -> TestContext:

--- a/oc_config_validate/oc_config_validate/runner.py
+++ b/oc_config_validate/oc_config_validate/runner.py
@@ -109,7 +109,7 @@ def makeTestSuite(test_class_name: str,
                                suiteClass=testbase.TestSuite)
     suite.test_class_name = test_class_name
     suite.test_name = test_name
-    return suite
+    return suite    # pytype: disable=bad-return-type
 
 
 def getClassFromPath(class_name: str) -> Optional[testbase.TestCase]:
@@ -194,7 +194,15 @@ def setInitConfigs(ctx: context.TestContext,
 
     """
     for init_config in ctx.init_configs:
+        # Provide init_config file and xpath
+        if not init_config.filename or not init_config.xpath:
+            logging.error(
+                "Initial configuration file and xpath are both needed: %s:%s",
+                init_config.filename, init_config.xpath)
+            if stop_on_error:
+                return False
         try:
+
             target.parsePath(init_config.xpath)
             tgt.gNMISetConfigFile(init_config.filename, init_config.xpath)
             logging.info("Initial OpenConfig '%s' applied at %s",

--- a/oc_config_validate/oc_config_validate/testbase.py
+++ b/oc_config_validate/oc_config_validate/testbase.py
@@ -307,7 +307,7 @@ class TestResult(unittest.TestResult):
     def addError(self, test: TestCase, err):
         """Override parent addError to support logging."""
         log = '%s\n%s' % (
-            self.log_message, self._exc_info_to_string(err, test))
+            self.log_message, self._exc_info_to_string(err, test))  # pytype: disable=attribute-error
         self.errors.append((test, log))
         self._mirrorOutput = True
         logging.error("%s - ERR:\n%s", test, log)
@@ -316,7 +316,7 @@ class TestResult(unittest.TestResult):
     def addFailure(self, test: TestCase, err):
         """Override parent addFailure to support logging."""
         log = '%s\n %s' % (
-            self.log_message, self._exc_info_to_string(err, test))
+            self.log_message, self._exc_info_to_string(err, test))  # pytype: disable=attribute-error
         self.failures.append((test, log))
         self._mirrorOutput = True
         logging.error("%s - FAIL:\n%s", test, log)


### PR DESCRIPTION
This allows for a self-contained test file, with the option to override some of the targe options from the command line.