### PR TITLE
OC system model bindings built separately

### DIFF
--- a/oc_config_validate/oc_config_validate/.gitignore
+++ b/oc_config_validate/oc_config_validate/.gitignore
@@ -1,3 +1,5 @@
 /__pycache__/
 **/__pycache__/
 /oc_config_validate.egg-info/
+/models/*.py
+/models/**/*.py

--- a/oc_config_validate/oc_config_validate/models/versions
+++ b/oc_config_validate/oc_config_validate/models/versions
@@ -3,8 +3,8 @@ openconfig-if-ip@2019-01-08
 openconfig-access-points@2020-04-28
 openconfig-ap-interfaces@2020-03-24
 openconfig-ap-manager@2020-06-30
-openconfig-system@2021-07-20
-openconfig-aaa@2020-07-30
 openconfig-local-routing@2020-03-24
 openconfig-bgp@2021-06-16
 openconfig-lldp@2018-11-21
+openconfig-system@2021-07-20
+openconfig-aaa@2020-07-30

--- a/oc_config_validate/oc_config_validate/update_models.sh
+++ b/oc_config_validate/oc_config_validate/update_models.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#
 # Code taken and adapted from 
 # https://github.com/openconfig/gnmitest/blob/master/schemas/openconfig/update.sh,
 # under Apache License, Version 2.0.
@@ -27,21 +26,25 @@ git clone --depth 1 https://github.com/openconfig/public.git "$MODELS_FOLDER/pub
 
 PYBINDPLUGIN=$(/usr/bin/env python -c 'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))')
 
-MODELS=( "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-interfaces.yang" \
+_MODELS=( "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-interfaces.yang" \
           "${MODELS_FOLDER}/public/release/models/interfaces/openconfig-if-ip.yang" \
           "${MODELS_FOLDER}/public/release/models/wifi/openconfig-access-points.yang" \
           "${MODELS_FOLDER}/public/release/models/wifi/openconfig-ap-interfaces.yang" \
           "${MODELS_FOLDER}/public/release/models/wifi/openconfig-ap-manager.yang" \
-          "${MODELS_FOLDER}/public/release/models/system/openconfig-system.yang" \
-          "${MODELS_FOLDER}/public/release/models/system/openconfig-aaa.yang" \
           "${MODELS_FOLDER}/public/release/models/local-routing/openconfig-local-routing.yang" \
           "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp.yang" \
-          "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp-global.yang" \
-          "${MODELS_FOLDER}/public/release/models/bgp/openconfig-bgp-neighbor.yang" \
           "${MODELS_FOLDER}/public/release/models/lldp/openconfig-lldp.yang" )
 
+SYSTEM_MODELS=( "${MODELS_FOLDER}/public/release/models/system/openconfig-system.yang" \
+                "${MODELS_FOLDER}/public/release/models/system/openconfig-aaa.yang"  )
+
+MODELS=( ${_MODELS[@]} ${SYSTEM_MODELS[@]} )
+
 pyang --plugindir $PYBINDPLUGIN -f pybind  --path "$MODELS_FOLDER/" \
-  --split-class-dir "$MODELS_FOLDER/" ${MODELS[@]}
+  --split-class-dir "$MODELS_FOLDER/" ${SYSTEM_MODELS[@]}
+
+pyang --plugindir $PYBINDPLUGIN -f pybind  --path "$MODELS_FOLDER/" \
+  --split-class-dir "$MODELS_FOLDER/" ${_MODELS[@]}
 
 pyang --plugindir $PYBINDPLUGIN -f name --name-print-revision \
   --path "$MODELS_FOLDER/" --output "$MODELS_FOLDER/versions" ${MODELS[@]}

--- a/oc_config_validate/tests/system.yaml
+++ b/oc_config_validate/tests/system.yaml
@@ -8,71 +8,43 @@ labels:
 tests:
 
 - !TestCase
-  name: "Check System Config model validity"
+  name: "Check System model validity"
   class_name: get.GetJsonCheck
   args:
     xpath: "/system"
     model: system.system
 
 - !TestCase
-  name: "Set Hostname and Domain"
-  class_name: set.JsonCheckSetUpdate
+  name: "Set and Check Hostname and Domain"
+  class_name: config_state.SetConfigCheckState
   args:
-    xpath: "/system/config"
-    model: system.config.config
+    xpath: "/system"
+    model: "system"
     json_value: {
-      "openconfig-system:domain-name": "corp.google.com",
-      "openconfig-system:hostname": "foobar"
+      "domain-name": "google.com",
+      "hostname": "foobar"
     }
 
 - !TestCase
-  name: "Compare Hostname and Domain configured"
-  class_name: get.GetCompare
-  args:
-    xpath: "/system/config"
-    want: {
-      "config": {
-        "domain-name": "corp.google.com",
-        "hostname": "foobar"
-      }
-    }
-
-- !TestCase
-  name: "Check Hostname and Domain configured"
-  class_name: get.GetJsonCheck
-  args:
-    xpath: "/system/config"
-    model: system.config.config
-
-- !TestCase
-  name: "Set Hostname and Domain"
+  name: "Update Hostname"
   class_name: setget.JsonCheckCompare
   args:
     xpath: "/system/config"
     model: system.config.config
     json_value: {
-      "openconfig-system:domain-name": "prod.google.com",
-      "openconfig-system:hostname": "lalala"
+      "hostname": "barbar"
     }
 
 - !TestCase
   name: "Compare Hostname and Domain state"
-  class_name: get.GetCompare
+  class_name: get.GetJsonCheckCompare
   args:
     xpath: "/system/state"
-    want: {
-      "state": {
-        "domain-name": "prod.google.com",
-        "hostname": "lalala"
-      }
+    model: "system.state.state"
+    want_json: {
+        "domain-name": "googles.com",
+        "hostname": "barbar"
     }
-
-- !TestCase
-  name: "Check Hostname and Domain state"
-  class_name: get.GetJsonCheck
-  args:
-    xpath: "/system/state"
-    model: system.state.state
 
 - !TestCase
   name: "Set and Check Timezone"
@@ -81,5 +53,25 @@ tests:
     xpath: "/system/clock"
     model: "system.clock"
     json_value: {
-      "openconfig-system:timezone-name": "America/Los_Angeles"
+      "timezone-name": "America/Los_Angeles"
+    }
+
+- !TestCase
+  name: "Update and Check Timezone"
+  class_name: setget.JsonCheckCompare
+  args:
+    xpath: "/system/clock/config"
+    model: "system.clock.config.config"
+    json_value: {
+      "timezone-name": "Europe/Zurich"
+    }
+
+- !TestCase
+  name: "Compare Timezone state"
+  class_name: get.GetJsonCheckCompare
+  args:
+    xpath: "/system/clock/state"
+    model: "system.clock.state.state"
+    want_json: {
+        "timezone-name": "Europe/Zurich"
     }


### PR DESCRIPTION
The System OC model was missing the hostname leaf when binded along all other models.

Also, ignoring the generated Python files from Git.