### PR TITLE
Add retries for testcases that validate or compare after gNMI Sets

### DIFF
--- a/oc_config_validate/docs/testcases.md
+++ b/oc_config_validate/docs/testcases.md
@@ -25,18 +25,25 @@ class TestSomething(test_base.TestCase):
         resp = self.gNMIGet(self.a_path)
         self.assertEqual(resp.int_val, self.an_int )
 
+    @testbase.retryAssertionError
+    def test0100(self):
+        resp = self.gNMIGet(self.a_path)
+        self.assertEqual(resp.int_val, self.an_int )
+
 ```
 
 Important to notice:
 
  * All Class inherits from `test_base.TestCase`. 
- 
+
  * It is recommended to interact with the gNMI Target with methods like `self.gNMIGet()` and `self.gNMISetUpdate()`, but direct access to the Target is possible using `self.test_target`.
 
  * The Class will get as attributes the arguments passed from the Test YAML description. It would be beneficial to first test that the arguments were passed (check the existence of the attributes) at first.
 
+ * Some tests can retry if AssertionError was raised, with the decorator `@testbase.retryAssertionError`. The number of retries and delay are read from the Test YAML entry.
+
  * The Class has test methods, that **MUST** start with `test` prefix. The methods are executed in alphabetical order.
- 
+
  * The methods can call `unittests` methods, such as `assertTrue()`, `assertEqual()`, `log()`, `fail()`, etc.
 
 > Some testcases for simple gNMI GET and SET tests are already provided for use in the `oc_config_validate.testcases` module.

--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -16,6 +16,8 @@
     Args:
      *  `xpath`: gNMI path to read, like "system/config"
      *  `want`: Expected value; can be numeric, string or JSON-IETF
+     *  `retries`: Optional. Number of retries if the assertion fails
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10
 
  *  `get.GetJsonCheck`
 
@@ -24,7 +26,9 @@
     Args:
      *  `xpath`: gNMI path to read, like "system/config"
      *  `model`: Python binding class to check the JSON reply against.
-        like `system.config.config`. 
+        like `system.config.config`.
+     *  `retries`: Optional. Number of retries if the assertion fails.
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
         The binding classes are in the `oc_config_validate.models` package.
 
@@ -37,6 +41,8 @@
      *  `model`: Python binding class to check the JSON reply against.
         like `system.config.config`. 
      *  `want_json`: Expected JSON-IETF value.
+     *  `retries`: Optional. Number of retries if the assertion fails.
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
         The binding classes are in the `oc_config_validate.models` package.
 
@@ -83,6 +89,8 @@
      *  `json_value`: JSON-IETF value to check set and get.
      *  `model`: Python binding class to check the JSON reply against.
         like `system.config.config`.
+     *  `retries`: Optional. Number of retries if the assertion fails.
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
  *  `setget.JsonCheckCompare`
 
@@ -99,6 +107,8 @@
      *  `json_value`: JSON-IETF value to check set, get and compare.
      *  `model`: Python binding class to check the JSON reply against.
         like `system.config.config`.
+     *  `retries`: Optional. Number of retries if the assertion fails.
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
 ### Module config_state
 
@@ -120,6 +130,8 @@
      *  `xpath`: gNMI path to write and read, without ending /config or /state.
      *  `json_value`: JSON-IETF value to check set, get and compare.
      *  `model`: Python binding class to check the JSON reply against.
+     *  `retries`: Optional. Number of retries if the assertion fails.
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
  *  `config_state.DeleteConfigCheckState`
  
@@ -135,8 +147,12 @@
 
     Args:
      *  `xpath`: gNMI path to delete, without ending /config or /state.
+     *  `retries`: Optional. Number of retries if the assertion fails.
+     *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
 ### Module static_route
+
+By default, the tests do 3 retries, with 10 seconds delay, if the assertion fails.
 
  *  `static_route.AddStaticRoute`
 
@@ -199,6 +215,8 @@
      * `description`: Optional text description of the route.
 
 ### Module subif_ip
+
+By default, the tests do 3 retries, with 10 seconds delay, if the assertion fails.
 
  *  `subif_ip.SetSubifDhcp`
  

--- a/oc_config_validate/oc_config_validate/testcases/config_state.py
+++ b/oc_config_validate/oc_config_validate/testcases/config_state.py
@@ -2,8 +2,6 @@
 
 import json
 
-from retry import retry
-
 from oc_config_validate import schema, target, testbase
 
 
@@ -46,7 +44,7 @@ class SetConfigCheckState(testbase.TestCase):
                 self.xpath.rstrip("/") + "/config", self.json_value),
             "gNMI Set did not succeed.")
 
-    @retry(exceptions=AssertionError, tries=2, delay=10)
+    @testbase.retryAssertionError
     def test0200(self):
         """gNMI Get on /config"""
         self.assertArgs(["xpath", "model", "json_value"])
@@ -58,7 +56,7 @@ class SetConfigCheckState(testbase.TestCase):
         cmp, diff = target.intersectCmp(got, self.json_value)
         self.assertTrue(cmp, diff)
 
-    @retry(exceptions=AssertionError, tries=5, delay=10)
+    @testbase.retryAssertionError
     def test0300(self):
         """gNMI Get on /state"""
         self.assertArgs(["xpath", "model", "json_value"])
@@ -105,14 +103,14 @@ class DeleteConfigCheckState(testbase.TestCase):
             self.gNMISetDelete(self.xpath.rstrip("/")),
             "gNMI Delete did not succeed.")
 
-    @retry(exceptions=AssertionError, tries=2, delay=10)
+    @testbase.retryAssertionError
     def test0300(self):
         """gNMI Get on /config to verify it is deleted"""
         self.assertFalse(
             self.gNMIGet(self.xpath.rstrip("/") + "/config"),
             "There is still a /config container for the xpath.")
 
-    @retry(exceptions=AssertionError, tries=3, delay=10)
+    @testbase.retryAssertionError
     def test0400(self):
         """gNMI Get on /state to verify it is deleted"""
         self.assertFalse(

--- a/oc_config_validate/oc_config_validate/testcases/get.py
+++ b/oc_config_validate/oc_config_validate/testcases/get.py
@@ -35,6 +35,7 @@ class GetCompare(testbase.TestCase):
     xpath = ""
     want = ""
 
+    @testbase.retryAssertionError
     def test0200(self):
         """"""
         self.assertArgs(["xpath", "want"])
@@ -64,6 +65,7 @@ class GetJsonCheck(testbase.TestCase):
     xpath = ""
     model = ""
 
+    @testbase.retryAssertionError
     def test0200(self):
         """"""
         self.assertArgs(["xpath", "model"])
@@ -94,6 +96,7 @@ class GetJsonCheckCompare(testbase.TestCase):
     model = ""
     want_json = None
 
+    @testbase.retryAssertionError
     def test0200(self):
         """"""
         self.assertArgs(["xpath", "want_json", "model"])

--- a/oc_config_validate/oc_config_validate/testcases/setget.py
+++ b/oc_config_validate/oc_config_validate/testcases/setget.py
@@ -48,6 +48,10 @@ class JsonCheck(TestCase):
         """"""
         self.assertTrue(self.gNMISetUpdate(self.xpath, self.json_value),
                         "gNMI Set did not succeed.")
+
+    @testbase.retryAssertionError
+    def test0200(self):
+        """"""
         resp = self.gNMIGet(self.xpath)
         self.assertIsNotNone(resp, "No gNMI GET response")
         self.resp_val = resp.json_ietf_val
@@ -74,10 +78,14 @@ class JsonCheckCompare(JsonCheck):
         model: Python binding class to check the JSON reply against.
     """
 
-    def test0200(self):
+    @testbase.retryAssertionError
+    def test0300(self):
         """"""
-        if not hasattr(self, "resp_val") or not self.resp_val:
-            self.skipTest("No JSON response to compare")
+        resp = self.gNMIGet(self.xpath)
+        self.assertIsNotNone(resp, "No gNMI GET response")
+        self.resp_val = resp.json_ietf_val
+        self.assertIsNotNone(self.resp_val,
+                             "The gNMI GET response is not JSON IETF")
         got = json.loads(self.resp_val)
         cmp, diff = target.intersectCmp(got, self.json_value)
         self.assertTrue(cmp, diff)

--- a/oc_config_validate/tests/system.yaml
+++ b/oc_config_validate/tests/system.yaml
@@ -18,6 +18,8 @@ tests:
   name: "Set and Check Hostname and Domain"
   class_name: config_state.SetConfigCheckState
   args:
+    retries: 3
+    retry_delay: 10
     xpath: "/system"
     model: "system"
     json_value: {
@@ -29,6 +31,8 @@ tests:
   name: "Update Hostname"
   class_name: setget.JsonCheckCompare
   args:
+    retries: 3
+    retry_delay: 10
     xpath: "/system/config"
     model: system.config.config
     json_value: {
@@ -50,6 +54,8 @@ tests:
   name: "Set and Check Timezone"
   class_name: config_state.SetConfigCheckState
   args:
+    retries: 3
+    retry_delay: 10
     xpath: "/system/clock"
     model: "system.clock"
     json_value: {
@@ -60,6 +66,8 @@ tests:
   name: "Update and Check Timezone"
   class_name: setget.JsonCheckCompare
   args:
+    retries: 3
+    retry_delay: 10
     xpath: "/system/clock/config"
     model: "system.clock.config.config"
     json_value: {


### PR DESCRIPTION
Some testcases were doing retry already, with fixed retries and delays. But some devices need more time to process certain OC configurations and reflect them on gNMI Gets. So now the basic testcases support defining retries when needed.

This is also a good indication of how long a Configuration Management systems needs to wait/retry before validating a configuration has been processed.