### PR TITLE
ValueErrors raised when binding are caught.

### DIFF
--- a/oc_config_validate/oc_config_validate/testbase.py
+++ b/oc_config_validate/oc_config_validate/testbase.py
@@ -241,7 +241,7 @@ class TestCase(unittest.case.TestCase):
         match, error = True, None
         try:
             schema.decodeJson(json_value, model_obj)
-        except AttributeError as err:
+        except (AttributeError, ValueError) as err:
             match, error = False, err
         self.assertTrue(match, "%s: %s" % (msg, error))
 


### PR DESCRIPTION
This avoids the surfacing a long and verbose exception stack.