### PR TITLE
Add cooldown delay after gNMI Set

### DIFF
--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -5,7 +5,7 @@ configurations of devices, using gNMI.
 
 ### Use case
 
-As a Network Operator or Administrator, I need to ensure the configuration of 
+As a Network Operator or Administrator, I need to ensure the configuration of
 devices using OpenConfig models and gNMI protocol works as intended, meaning:
 
  *  The device replies, without errors and with a valid OpenConfig model,
@@ -44,7 +44,7 @@ python3 -m oc_config_validate --version
 Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate`.
 
  1. It starts an instance of [gnmmi_target](https://github.com/google/gnxi/blob/master/gnmi_target/gnmi_target.go) with a sample configuration
- 1. It runs `oc_config_validate` with a sample test file. 
+ 1. It runs `oc_config_validate` with a sample test file.
  1. See `run_demo.sh -h` for additional TLS-connection options to use.
 
 > For the first execution, it first create local TLS certificates.
@@ -61,13 +61,13 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
     All initial configurations found on the test file and on the command line are applied, sequentially.
 
  1. Then, write your OpenConfig configuration tests, in YAML format.
- 
+
     [docs/tests.md](docs/tests.md) describes how to create your own tests.
 
     The are some tests already created at [tests/](tests/).
- 
+
  1. Finally, validate your configurations against a gNMI target using:
- 
+
 ```
     python3 -m oc_config_validate -tests TESTS_FILE -results RESULTS_FILE \
        [--target HOSTNAME:PORT] \
@@ -76,9 +76,9 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
        [-init INIT_CONFIG_FILE -xpath INIT_CONFIG_XPATH] \
        [--verbose] [--log_gnmi] [--stop_on_error]
 ```
-    
+
     For an example:
-    
+
 ```
     python3 -m oc_config_validate --target localhost:9339 \
        --username gnmi --password gnmi \
@@ -89,7 +89,7 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
 ```
 
  1. Expect an output similar to:
- 
+
 ```
     INFO(__main__.py:275):Read tests file 'demo/example.yaml': 16 tests to run
     INFO(__main__.py:283):Using TLS for gNMI connection
@@ -98,35 +98,35 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
     INFO(__main__.py:301):Initial OpenConfig 'demo/init_config.json' applied on gNMI xpath /system/config
     INFO(runner.py:58):Running Test 'Get System Config'
     INFO(runner.py:62):Test 'Get System Config' took 1.031494 msecs: PASS
-    
+
     INFO(runner.py:58):Running Test 'Check System Config'
     INFO(testbase.py:277):test0200 (oc_config_validate.testcases.get.GetJsonCheck) - FAIL:
-    
+
      Traceback (most recent call last):
       File "/usr/local/google/home/itamayo/oc_config_validate/oc_config_validate/testcases/get.py", line 83, in test0200
         self.assertJsonModel(resp_val, self.model,
       File "/usr/local/google/home/itamayo/oc_config_validate/oc_config_validate/testbase.py", line 233, in assertJsonModel
         self.assertTrue(match, "%s: %s" % (msg, err))
     AssertionError: False is not true : Get response JSON does not match model: JSON object contained a key that did not exist (hostname)
-    
+
     INFO(runner.py:62):Test 'Check System Config' took 4.437500 msecs: FAIL
-    
+
     INFO(runner.py:58):Running Test 'Check AAA State'
     INFO(runner.py:62):Test 'Check AAA State' took 1.718262 msecs: PASS
     ...
     INFO(runner.py:58):Running Test 'Set timezone with a valid Json blob'
     INFO(runner.py:62):Test 'Set timezone with a valid Json blob' took 60.581787 msecs: PASS
-    
+
     INFO(runner.py:58):Running Test 'Set timezone with a valid Json blob, and check it is Zurich'
     INFO(runner.py:62):Test 'Set timezone with a valid Json blob, and check it is Zurich' took 24.644043 msecs: PASS
-    
+
     INFO(runner.py:58):Running Test 'Bad Set Clock Check State'
     WARNING(api.py:40):False is not true : key openconfig-system:timezone-name: Europe/Stockholm != Europe/Paris, retrying in 10 seconds...
     WARNING(api.py:40):False is not true : key openconfig-system:timezone-name: Europe/Stockholm != Europe/Paris, retrying in 10 seconds...
     WARNING(api.py:40):False is not true : key openconfig-system:timezone-name: Europe/Stockholm != Europe/Paris, retrying in 10 seconds...
     WARNING(api.py:40):False is not true : key openconfig-system:timezone-name: Europe/Stockholm != Europe/Paris, retrying in 10 seconds...
     INFO(testbase.py:277):test0300 (oc_config_validate.testcases.config_state.SetConfigCheckState) - FAIL:
-    
+
      Traceback (most recent call last):
       File "/usr/local/google/home/itamayo/oc_config_validate/venv/lib/python3.9/site-packages/decorator.py", line 232, in fun
         return caller(func, *(extras + args), **kw)
@@ -137,9 +137,9 @@ Run the script `run_demo.sh` to see a quick demonstration of `oc_config_validate
       File "/usr/local/google/home/itamayo/oc_config_validate/oc_config_validate/testcases/config_state.py", line 81, in test0300
         self.assertTrue(cmp, diff)
     AssertionError: False is not true : key openconfig-system:timezone-name: Europe/Stockholm != Europe/Paris
-    
+
     INFO(runner.py:62):Test 'Bad Set Clock Check State' took 40082.661377 msecs: FAIL
-    
+
     INFO(__main__.py:310):Results Summary: PASS 10, FAIL 6
     INFO(__main__.py:315):Test results written to demo/results.json
 ```
@@ -153,12 +153,12 @@ the Root CA certificate from the Target.
  *  Use the `tls_host_override` option to provide the hostname value present
     in the Target's certificate.
  *  Use the `root_ca_cert` option to provide the Root CA certificate file to use.
- *  Use the `private_key` and `cert_chain` options to provide the TLS key and certificate 
+ *  Use the `private_key` and `cert_chain` options to provide the TLS key and certificate
     files that the client will present to the Target.
 
 In case of errors, use the `--debug` flag to help understand the underlying TLS issue, if any.
 
- > With care, use the `no_tls` option not to use TLS for the gNMI connection. 
+ > With care, use the `no_tls` option not to use TLS for the gNMI connection.
  >
  > Warning: All communication will be in plain text.
 
@@ -189,6 +189,15 @@ pyang --plugindir $PYBINDPLUGIN -f name --name-print-revision \
   $MODELS
 
 ```
+
+#### Timing in gNMI Sets and Gets
+
+The Target can take some time to process configurations done via gNMI Set messages. By default, `oc_config_validate` waits 10 seconds after a successful gNMI Set message.
+This time is customized with the `gnmi_set_cooldown_secs` option in the targe configuration or in a command line argument.
+
+Similarly, the Target can take some time to show the expected values in a gNMI Get message.
+Some testcases have a retry mechanism, that will repeat the gNMI Get message and comparisons (against an OC model, against an expected JSON text, or both) until it succeeds or times out.
+See [docs/testclasses](docs/testclasses.md) for more details.
 
 ## Copyright
 

--- a/oc_config_validate/demo/tests.yaml
+++ b/oc_config_validate/demo/tests.yaml
@@ -9,6 +9,7 @@ target:
   !Target
   target: "localhost:8080"
   tls_host_override: "target.com"
+  gnmi_set_cooldown_secs: 2
 
 init_configs:
 - !InitConfig

--- a/oc_config_validate/docs/tests.md
+++ b/oc_config_validate/docs/tests.md
@@ -8,49 +8,50 @@
 # Informative text about this test run.
 description: [:string]
 
-# Optional list of text labels, passed to the Results. Can be used for tagging and filtering. 
-labels: 
+# Optional list of text labels, passed to the Results. Can be used for tagging and filtering.
+labels:
 - [:string]
 - [:string]
 
-# Target to connect to. Overridden by command arguments
+# Target to connect to. Overridden by command arguments.
 target:
   !Target
-  target: [:string]  # As "hostname:port"
+  target: [:string]  # As "hostname:port".
   username: [:string]
   password: [:string]  # Attention, this is clear text.
   no_tls: [:bool]
-  private_key: [:string]  # Path to file
-  cert_chain: [:string]  # Path to file
-  root_ca_cert: [:string]  # Path to file
+  private_key: [:string]  # Path to file.
+  cert_chain: [:string]  # Path to file.
+  root_ca_cert: [:string]  # Path to file.
   tls_host_override: [:string]
+  gnmi_set_cooldown_secs: [:int]  # Time to wait after a successful gNMI Set.
 
 # Optional list of initial configurations and xpaths to apply before the tests.
 init_configs:
 - !InitConfig
   # Path to the initial configuration JSON file.
   filename: [:string]
-  #Xpath where to send a gNMI Set Update messages with the configuration.
+  # Xpath where to send a gNMI Set Update messages with the configuration.
   xpath: [:string]
-  
-# List of Tests to run
-tests: 
+
+# List of Tests to run.
+tests:
 - !TestCase
   # Short description of what is being tested.
   name: [:string]
   # A valid class in the oc_config_validate.testcases module
   class_name: [:string]
   # Optional list of arguments required by the class.
-  args: 
+  args:
     [:string]: [:any]
 ```
 
 > The Tags like `!TestContext` and `!TestCase` are needed to easily parse the YAML into objects.
 
-A test run is made of a sequence of tests. Each test is made of a Class, in 
+A test run is made of a sequence of tests. Each test is made of a Class, in
 the `oc_config_validate.testcases` module, that tests something (it can be as simple as testing a gNMI Get is successful).
 
-Each Class accepts or needs some arguments, which are passed in the `args:` section. See the class documentation to provide its arguments. 
+Each Class accepts or needs some arguments, which are passed in the `args:` section. See the class documentation to provide its arguments.
 
 > Some `oc_config_validate` tests files for common network devices are already curated in the [tests/](../tests) folder.
 
@@ -63,7 +64,7 @@ The way to compare the JSON values given in the tests with the responses obtaine
  1.  Only the keys from the JSON in the tests are compared. The gNMI response can have more members in the JSON, those are not compared.
  1.  For key in the JSON in the test, the values are compared for equality in the gNMI response.
  1.  If there are nested JSON objects, the same comparison is applied to them.
- 1.  If a key contains a list of JSON objects, all objects in the list in the JSON text in the tests must be present in the gNMI response. 
+ 1.  If a key contains a list of JSON objects, all objects in the list in the JSON text in the tests must be present in the gNMI response.
      The gNMI response can have more elements in the list, those are not compared.
  1.  The same comparison mechanism applies to JSON objects contained in a list, in the JSON text in the tests.
 

--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -43,39 +43,39 @@ def createArgsParser() -> argparse.ArgumentParser:
         "-tgt",
         "--target",
         type=str,
-        help="The gNMI Target, as hostname:port",
+        help="The gNMI Target, as hostname:port.",
     )
     parser.add_argument(
         "-user",
         "--username",
         type=str,
-        help="Username to use when establishing a gNMI Channel to the Target",
+        help="Username to use when establishing a gNMI Channel to the Target.",
     )
     parser.add_argument(
         "-pass",
         "--password",
         type=str,
-        help="Password to use when establishing a gNMI Channel to the Target",
+        help="Password to use when establishing a gNMI Channel to the Target.",
     )
     parser.add_argument(
         "-key",
         "--private_key",
         type=str,
         help="Path to the Private key to use when establishing"
-        "a gNMI Channel to the Target",
+        "a gNMI Channel to the Target.",
     )
     parser.add_argument(
         "-ca",
         "--root_ca_cert",
         type=str,
-        help="Path to Root CA to use when building the gNMI Channel",
+        help="Path to Root CA to use when building the gNMI Channel.",
     )
     parser.add_argument(
         "-cert",
         "--cert_chain",
         type=str,
         help="Path to Certificate chain to use when"
-        "establishing a gNMI Channel to the Target")
+        "establishing a gNMI Channel to the Target.")
     parser.add_argument(
         "-tests",
         "--tests_file",
@@ -114,29 +114,36 @@ def createArgsParser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-v", "--version", help="Print program version", action="store_true")
     parser.add_argument(
-        "-V", "--verbose", help="Enable gRPC debugging and extra logging",
+        "-V", "--verbose", help="Enable gRPC debugging and extra logging.",
         action="store_true")
     parser.add_argument(
-        "-models", "--oc_models_versions", help="Print OC models versions",
+        "-models", "--oc_models_versions", help="Print OC models versions.",
         action="store_true")
     parser.add_argument(
-        "--no_tls", help="gRPC insecure mode", action="store_true")
+        "--no_tls", help="gRPC insecure mode.", action="store_true")
     parser.add_argument(
         "-o",
         "--tls_host_override",
         type=str,
         action="store",
-        help="Hostname to use during the TLS certificate check",
+        help="Hostname to use during the TLS certificate check.",
+    )
+    parser.add_argument(
+        "-set_cooldown",
+        "--gnmi_set_cooldown_secs",
+        type=str,
+        action="store",
+        help="Seconds to wait after a successful gNMI Set message.",
     )
     parser.add_argument(
         "--stop_on_error",
         action="store_true",
-        help="Stop the execution if a test fails",
+        help="Stop the execution if a test fails.",
     )
     parser.add_argument(
         "--log_gnmi",
         action="store_true",
-        help="Log the gnmi requests to the tests results",
+        help="Log the gnmi requests to the tests results.",
     )
     return parser
 
@@ -227,6 +234,10 @@ def main():  # noqa
         sys.exit("Invalid Target: %s" % error)
 
     logging.info("Testing gNMI Target %s.", tgt)
+
+    if tgt.gnmi_set_cooldown_secs:
+        logging.info("Using gNMI Set Cooldown of %d secs",
+                     tgt.gnmi_set_cooldown_secs)
 
     # Apply initial configuration
     if args["init_config_file"]:

--- a/oc_config_validate/oc_config_validate/context.py
+++ b/oc_config_validate/oc_config_validate/context.py
@@ -85,6 +85,7 @@ class Target(yaml.YAMLObject):
     cert_chain = ""
     no_tls = False
     tls_host_override = ""
+    gnmi_set_cooldown_secs = 10
 
     def __repr__(self):
         return 'Target(target=%r, no_tls=%r)' % (self.target, self.no_tls)


### PR DESCRIPTION
Targets needs some time to process configuation after a successful gNMI
Set request.

Also, correcting lint errors in .md files, and puntuation in help
messages in the command line.