### PR TITLE
Create Python bindings for all public OC models

### DIFF
--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -177,12 +177,14 @@ In case of errors, use the `--debug` flag to help understand the underlying TLS 
 
 #### OpenConfig Models
 
-`oc_config_validate` includes the Python bindings of some OpenConfig models, in the package `oc_config_validate.models`.
+`oc_config_validate` includes the Python bindings of [all public OpenConfig models](https://github.com/openconfig/public.git), in the package `oc_config_validate.models`.
 
  *  To update the bindings to the latest model versions, run `update_models.sh`
  *  To add more OpenConfig models, update `update_models.sh`
 
-The model bindings are used in tests that validate the gNMI JSON payloads against the expected OpenConfig model. See [docs/tests](docs/tests.md) for more details.
+The model bindings are used in tests that validate the gNMI JSON payloads against the OpenConfig model. See [docs/testclasses](docs/testclasses.md) for more details.
+
+The Python bindings are in a directory tree structure that allows to reference any container element of any OpenConfig model, for validation or to write specific testcases.
 
 Run `python3 -m oc_config_validate -models` to get a list of the versions (revisions) of the OC models used. These are also added to the results file.
 
@@ -191,16 +193,15 @@ Run `python3 -m oc_config_validate -models` to get a list of the versions (revis
 If specific OpenConfig models need to be used, place them in a directory (here `$MODELS_DIRECTORY`) and have **pyang** create the bindings and store them in `oc_config_validate/models/` (also write their revisions in `oc_config_validate/models/versions`):
 
 ```
+
 MODELS=$(find "$MODELS_DIRECTORY" -name *.yang)
 PYBINDPLUGIN=$(/usr/bin/env python -c 'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))')
 
-pyang --plugindir $PYBINDPLUGIN -f pybind  --path oc_config_validate/models/ \
+pyang --plugindir $PYBINDPLUGIN -f pybind  --path $MODELS_DIRECTORY/ \
   --split-class-dir oc_config_validate/models/ $MODELS
 
 pyang --plugindir $PYBINDPLUGIN -f name --name-print-revision \
-  --path oc_config_validate/models/ --output oc_config_validate/models/versions \
-  $MODELS
-
+  --path $MODELS_DIRECTORY/ $MODELS >> --output oc_config_validate/models/versions
 ```
 
 #### Timing in gNMI Sets and Gets

--- a/oc_config_validate/docs/testcases.md
+++ b/oc_config_validate/docs/testcases.md
@@ -7,6 +7,7 @@ The signature of a testcase Class is:
 
 ```
 from oc_config_validate import test_base
+from oc_config_validate.models import openconfig_model
 
 
 class TestSomething(test_base.TestCase):
@@ -34,16 +35,23 @@ class TestSomething(test_base.TestCase):
 
 Important to notice:
 
- * All Class inherits from `test_base.TestCase`. 
-
- * It is recommended to interact with the gNMI Target with methods like `self.gNMIGet()` and `self.gNMISetUpdate()`, but direct access to the Target is possible using `self.test_target`.
-
- * The Class will get as attributes the arguments passed from the Test YAML description. It would be beneficial to first test that the arguments were passed (check the existence of the attributes) at first.
-
- * Some tests can retry if AssertionError was raised, with the decorator `@testbase.retryAssertionError`. The number of retries and delay are read from the Test YAML entry.
+ * All Class inherits from `test_base.TestCase`.
 
  * The Class has test methods, that **MUST** start with `test` prefix. The methods are executed in alphabetical order.
 
  * The methods can call `unittests` methods, such as `assertTrue()`, `assertEqual()`, `log()`, `fail()`, etc.
+
+ * It is recommended to interact with the gNMI Target with methods like `self.gNMIGet()` and `self.gNMISetUpdate()`, but direct access to the Target is possible using `self.test_target`.
+
+ * The OpenConfig models, in Python classes, can be imported from `oc_config_validate.models` package.
+
+* Some tests can retry if AssertionError was raised, with the decorator `@testbase.retryAssertionError`. The number of retries and delay are read from the Test YAML entry.
+
+ * The Class will get as attributes the arguments passed from the Test YAML description. It would be beneficial to first test that the arguments were passed (check the existence of the attributes) at first.
+
+
+
+
+
 
 > Some testcases for simple gNMI GET and SET tests are already provided for use in the `oc_config_validate.testcases` module.

--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -25,7 +25,7 @@ import yaml
 from oc_config_validate import (context, formatter, runner, schema, target,
                                 testbase)
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 LOGGING_FORMAT = "%(levelname)s(%(filename)s:%(lineno)d):%(message)s"
 

--- a/oc_config_validate/oc_config_validate/models/versions
+++ b/oc_config_validate/oc_config_validate/models/versions
@@ -1,11 +1,163 @@
-openconfig-interfaces@2021-04-06
-openconfig-if-ip@2019-01-08
-openconfig-access-points@2021-08-02
-openconfig-ap-interfaces@2021-08-02
-openconfig-ap-manager@2021-08-02
-openconfig-local-routing@2020-03-24
-openconfig-lldp@2018-11-21
-openconfig-system@2021-07-20
-openconfig-aaa@2020-07-30
+openconfig-packet-match@2021-06-16
+openconfig-packet-match-types@2021-07-14
+openconfig-acl@2021-06-16
+openconfig-aft-ipv4@2021-12-09 (belongs-to openconfig-aft)
+openconfig-aft-network-instance@2018-11-21
+openconfig-aft-ethernet@2021-12-09 (belongs-to openconfig-aft)
+openconfig-aft-common@2021-12-09 (belongs-to openconfig-aft)
+openconfig-aft-ipv6@2021-12-09 (belongs-to openconfig-aft)
+openconfig-aft-pf@2021-12-09 (belongs-to openconfig-aft)
+openconfig-aft-types@2021-08-24
+openconfig-aft@2021-12-09
+openconfig-aft-mpls@2021-12-09 (belongs-to openconfig-aft)
+openconfig-ate-intf@2019-08-07
+openconfig-ate-flow@2019-08-07
+openconfig-bgp-global@2021-10-21 (belongs-to openconfig-bgp)
+openconfig-bgp-neighbor@2021-10-21 (belongs-to openconfig-bgp)
 openconfig-bgp@2021-10-21
+openconfig-bgp-peer-group@2021-10-21 (belongs-to openconfig-bgp)
+openconfig-bgp-common@2021-10-21 (belongs-to openconfig-bgp)
+openconfig-bgp-common-multiprotocol@2021-10-21 (belongs-to openconfig-bgp)
+openconfig-bgp-types@2021-08-06
+openconfig-bgp-common-structure@2021-10-21 (belongs-to openconfig-bgp)
+openconfig-bgp-policy@2020-06-30
+openconfig-bgp-errors@2021-08-06 (belongs-to openconfig-bgp-types)
+openconfig-module-catalog@2018-11-21
+openconfig-catalog-types@2018-11-21
+openconfig-codegen-extensions@2020-10-05
+openconfig-metadata@2020-08-06
+openconfig-fw-high-availability@2021-06-16
+openconfig-fw-link-monitoring@2021-06-16
+openconfig-gribi@2021-04-06
+openconfig-if-tunnel@2018-11-21
+openconfig-if-ethernet-ext@2018-11-21
+openconfig-if-8021x@2020-01-28
+openconfig-if-poe@2018-11-21
+openconfig-if-sdn-ext@2021-03-30
+openconfig-if-ip-ext@2018-11-21
+openconfig-if-ip@2019-01-08
+openconfig-if-aggregate@2020-05-01
+openconfig-interfaces@2021-04-06
+openconfig-if-ethernet@2021-07-07
+openconfig-if-types@2018-11-21
+openconfig-isis-lsdb-types@2018-11-21
+openconfig-isis-lsp@2022-01-19 (belongs-to openconfig-isis)
+openconfig-isis@2022-01-19
+openconfig-isis-policy@2020-02-04
+openconfig-isis-types@2021-08-12
+openconfig-isis-routing@2022-01-19 (belongs-to openconfig-isis)
+openconfig-keychain@2021-12-31
+openconfig-keychain-types@2021-10-01
+openconfig-lacp@2021-07-20
+openconfig-lldp@2018-11-21
+openconfig-lldp-types@2018-11-21
+openconfig-local-routing@2020-03-24
+openconfig-macsec@2020-05-01
+openconfig-macsec-types@2019-07-01
+openconfig-mpls-sr@2018-11-21
+openconfig-mpls-types@2021-06-16
+openconfig-mpls@2021-07-28
+openconfig-mpls-igp@2021-07-28 (belongs-to openconfig-mpls)
+openconfig-mpls-ldp@2020-01-09
+openconfig-mpls-te@2021-07-28 (belongs-to openconfig-mpls)
+openconfig-mpls-rsvp@2021-07-28
+openconfig-mpls-static@2021-07-28 (belongs-to openconfig-mpls)
+openconfig-pim@2021-06-16
+openconfig-igmp@2021-05-17
+openconfig-igmp-types@2018-11-21
+openconfig-pim-types@2018-11-21
+openconfig-network-instance-policy@2018-11-21
+openconfig-network-instance-l2@2021-11-17 (belongs-to openconfig-network-instance)
+openconfig-network-instance-types@2021-07-14
+openconfig-evpn@2021-06-11
 openconfig-network-instance@2021-11-17
+openconfig-network-instance-l3@2018-11-21
+openconfig-evpn-types@2021-06-16
+openconfig-extensions@2020-06-16
+openconfig-openflow@2018-11-21
+openconfig-openflow-types@2020-06-30
+openconfig-optical-amplifier@2019-12-06
+openconfig-transport-line-common@2019-06-03
+openconfig-transport-line-protection@2018-11-21
+openconfig-transport-types@2021-03-22
+openconfig-terminal-device@2021-02-23
+openconfig-transport-line-connectivity@2019-06-27
+openconfig-wavelength-router@2021-07-26
+openconfig-channel-monitor@2019-10-24
+openconfig-optical-attenuator@2019-07-19
+openconfig-ospfv2@2021-07-28
+openconfig-ospfv2-lsdb@2021-07-28 (belongs-to openconfig-ospfv2)
+openconfig-ospf-types@2018-11-21
+openconfig-ospfv2-area@2021-07-28 (belongs-to openconfig-ospfv2)
+openconfig-ospfv2-area-interface@2021-07-28 (belongs-to openconfig-ospfv2)
+openconfig-ospfv2-global@2021-07-28 (belongs-to openconfig-ospfv2)
+openconfig-ospf-policy@2018-11-21
+openconfig-ospfv2-common@2021-07-28 (belongs-to openconfig-ospfv2)
+openconfig-p4rt@2021-07-20
+openconfig-platform-software@2021-06-16
+openconfig-platform-types@2021-01-18
+openconfig-platform-fan@2018-11-21
+openconfig-platform@2021-08-13
+openconfig-platform-cpu@2018-11-21
+openconfig-platform-integrated-circuit@2021-08-09
+openconfig-platform-pipeline-counters@2021-10-16
+openconfig-platform-ext@2018-11-21
+openconfig-platform-transceiver@2021-02-23
+openconfig-platform-linecard@2020-05-10
+openconfig-platform-port@2021-10-01
+openconfig-platform-psu@2018-11-21
+openconfig-policy-types@2021-12-10
+openconfig-routing-policy@2020-08-18
+openconfig-pf-path-groups@2021-08-06 (belongs-to openconfig-policy-forwarding)
+openconfig-pf-forwarding-policies@2021-08-06 (belongs-to openconfig-policy-forwarding)
+openconfig-pf-srte@2019-10-15
+openconfig-policy-forwarding@2021-08-06
+openconfig-pf-interfaces@2021-08-06 (belongs-to openconfig-policy-forwarding)
+openconfig-probes@2018-11-21
+openconfig-probes-types@2018-11-21
+openconfig-qos-types@2018-11-21
+openconfig-qos-interfaces@2021-08-28 (belongs-to openconfig-qos)
+openconfig-qos@2021-08-28
+openconfig-qos-mem-mgmt@2021-08-28 (belongs-to openconfig-qos)
+openconfig-qos-elements@2021-08-28 (belongs-to openconfig-qos)
+openconfig-relay-agent@2018-11-21
+openconfig-rib-bgp-shared-attributes@2019-10-15 (belongs-to openconfig-rib-bgp)
+openconfig-rib-bgp-ext@2019-04-25
+openconfig-rib-bgp-attributes@2019-10-15 (belongs-to openconfig-rib-bgp)
+openconfig-rib-bgp-table-attributes@2019-10-15 (belongs-to openconfig-rib-bgp)
+openconfig-rib-bgp-types@2019-03-14
+openconfig-rib-bgp@2019-10-15
+openconfig-rib-bgp-tables@2019-10-15 (belongs-to openconfig-rib-bgp)
+openconfig-sampling-sflow@2020-06-26
+openconfig-segment-routing@2021-07-28
+openconfig-segment-routing-types@2020-02-04
+openconfig-rsvp-sr-ext@2019-07-09
+openconfig-srte-policy@2021-07-28
+openconfig-spanning-tree-types@2021-06-16
+openconfig-spanning-tree@2019-11-28
+openconfig-aaa-radius@2020-07-30 (belongs-to openconfig-aaa)
+openconfig-aaa-tacacs@2020-07-30 (belongs-to openconfig-aaa)
+openconfig-aaa@2020-07-30
+openconfig-system-grpc@2021-06-16
+openconfig-messages@2018-08-13
+openconfig-procmon@2019-03-15
+openconfig-system-terminal@2018-11-21
+openconfig-system-logging@2018-11-21
+openconfig-alarms@2019-07-09
+openconfig-aaa-types@2018-11-21
+openconfig-alarm-types@2018-11-21
+openconfig-license@2020-04-22
+openconfig-system@2021-07-20
+openconfig-telemetry-types@2018-11-21
+openconfig-telemetry@2018-11-21
+openconfig-types@2019-04-16
+openconfig-inet-types@2021-08-17
+openconfig-yang-types@2021-07-14
+openconfig-vlan-types@2020-06-30
+openconfig-vlan@2021-07-28
+openconfig-wifi-types@2021-08-02
+openconfig-wifi-phy@2021-08-02
+openconfig-ap-manager@2021-08-02
+openconfig-wifi-mac@2021-08-02
+openconfig-ap-interfaces@2021-08-02
+openconfig-access-points@2021-08-02

--- a/oc_config_validate/oc_config_validate/testbase.py
+++ b/oc_config_validate/oc_config_validate/testbase.py
@@ -419,7 +419,6 @@ class TestRun():
 
     def __init__(self, ctx: context.TestContext):
         self.test_target = ctx.target.target
-        self.oc_models = schema.getOcModelsVersions()
         if ctx.description:
             self.description = ctx.description
         if ctx.labels:


### PR DESCRIPTION
This allows oc_config_validate to check agains any OC model and gNMI xpath (no more need to maintain a list of models and binding instructions).