### PR TITLE
Support for -prefix and -data_type in gnmi_get and -prefix for gnmi_set.

### DIFF
--- a/gnmi_get/gnmi_get.go
+++ b/gnmi_get/gnmi_get.go
@@ -65,6 +65,8 @@ var (
 	targetAddr       = flag.String("target_addr", "localhost:9339", "The target address in the format of host:port")
 	timeOut          = flag.Duration("time_out", 10*time.Second, "Timeout for the Get request, 10 seconds by default")
 	encodingName     = flag.String("encoding", "JSON_IETF", "value encoding format to be used")
+	prefix           = flag.String("prefix", "", "prefix for the path. this is optional. valid values: oc, srl.")
+	dataType         = flag.Int("data_type", 0, "dataType - 0 (ALL), 1 (CONFIG), 2 (STATE) 3 (OPERATIONAL). Default is 0.")
 )
 
 func main() {
@@ -92,6 +94,8 @@ func main() {
 		log.Exitf("Supported encodings: %s", strings.Join(gnmiEncodingList, ", "))
 	}
 
+	var dataTypeEnum = pb.GetRequest_DataType(*dataType)
+
 	var pbPathList []*pb.Path
 	var pbModelDataList []*pb.ModelData
 	for _, xPath := range xPathFlags {
@@ -115,10 +119,14 @@ func main() {
 		}
 	}
 
+	var pbPrefixPath = &pb.Path{Origin: string(*prefix)}
+
 	getRequest := &pb.GetRequest{
 		Encoding:  pb.Encoding(encoding),
 		Path:      pbPathList,
 		UseModels: pbModelDataList,
+		Prefix:    pbPrefixPath,
+		Type:      dataTypeEnum,
 	}
 	fmt.Println("== GetRequest:\n", proto.MarshalTextString(getRequest))
 

--- a/gnmi_set/gnmi_set.go
+++ b/gnmi_set/gnmi_set.go
@@ -53,6 +53,7 @@ var (
 	updateOpt  arrayFlags
 	targetAddr = flag.String("target_addr", "localhost:9339", "The target address in the format of host:port")
 	timeOut    = flag.Duration("time_out", 10*time.Second, "Timeout for the Set request, 10 seconds by default")
+	prefix     = flag.String("prefix", "", "prefix for the path. this is optional. valid values: oc, srl.")
 )
 
 func buildPbUpdateList(pathValuePairs []string) []*pb.Update {
@@ -145,10 +146,13 @@ func main() {
 	replaceList := buildPbUpdateList(replaceOpt)
 	updateList := buildPbUpdateList(updateOpt)
 
+	var pbPrefixPath = &pb.Path{Origin: string(*prefix)}
+
 	setRequest := &pb.SetRequest{
 		Delete:  deleteList,
 		Replace: replaceList,
 		Update:  updateList,
+		Prefix:  pbPrefixPath,
 	}
 	fmt.Println("== SetRequest:\n", proto.MarshalTextString(setRequest))
 


### PR DESCRIPTION
1. Add -prefix parameter to gnmi_set.
2. Add -prefix and -data_type to gnmi_get.

 data_type can be 0 (ALL), 1 (CONFIG), 2 (STATE) 3 (OPERATIONAL). Default is 0.

 prefix is a string that can be used in GNMI Get/Set messages. Default is none.