### PR TITLE
Add Docker images.

### DIFF
--- a/oc_config_validate/demo/Dockerfile
+++ b/oc_config_validate/demo/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-slim-bullseye
+
+RUN apt-get update
+RUN apt-get install -y git procps
+
+COPY --from=golang:1.18-bullseye /usr/local/go/ /usr/local/go/
+ENV PATH=$PATH:/usr/local/go/bin
+
+WORKDIR /opt
+RUN git clone https://github.com/google/gnxi.git
+RUN pip3 install -r ./gnxi/oc_config_validate/requirements.txt
+
+WORKDIR /opt/gnxi/oc_config_validate
+COPY run_demo.sh demo/run_demo.sh
+
+CMD /opt/gnxi/oc_config_validate/demo/run_demo.sh -L

--- a/oc_config_validate/demo/README.md
+++ b/oc_config_validate/demo/README.md
@@ -1,14 +1,39 @@
 # Demo
 
-Run the script `demo/run_demo.sh` to see a quick demonstration of `oc_config_validate`.
+1. It starts an instance of [gnmmi_target](../gnmi_target) with a sample
+   configuration.
 
- 1. It starts an instance of [gnmmi_target](../gnmi_target) with a sample configuration.
- 1. It runs `oc_config_validate` with a sample [test file](demo/tests.yaml).
- 1. It writes the results to [a JSON file](demo/results.json).
+1. It runs `oc_config_validate` with a [sample test file](demo/tests.yaml).
+
+1. It writes the results to [a file](demo/results.json).
+
+## On Docker
+
+Run the demo of `oc_config_validate` in a Docker container:
+
+```
+docker pull joseignaciotamayo/oc_config_validate:demo_latest
+
+docker run -it joseignaciotamayo/oc_config_validate:demo_latest
+
+```
+
+The Docker container just clones this repo and runs `demo/run_demo.sh`, on top of a *Debian bullseye* image.
+
+> This Docker image is large because it contains both the Python3 and Golang
+> runtimes.
+
+## From source
+
+Run the script `demo/run_demo.sh` on a Linux system to see a quick demonstration of
+`oc_config_validate`.
+
+ * `gnmmi_target` needs `golang>=1.17` runtime, install it first.
+ * The script assumes `oc_config_validate` and its dependencies are installed.
+   If you are using a *virtualenv*, you need to activate it before running
+   the demo.
 
 Run `demo/run_demo.sh -h` for additional options to use.
 
-> It uses the local TLS certificates from [gnxi/certs/](../certs/).
-
-> `gnmmi_target` needs `golang>=1.17` runtime, install it first.
- 
+> The script calls [generate.sh](../../certs/generate.sh) to create local TLS
+  certificates in [gnxi/certs/](../../certs/).

--- a/oc_config_validate/demo/run_demo.sh
+++ b/oc_config_validate/demo/run_demo.sh
@@ -25,14 +25,15 @@ start_gnmi_target() {
     fi
 
     echo "--- Start TARGET $OPTS"
+    go build ${GNMI_TARGET}
     go run ${GNMI_TARGET} -bind_address ":$1" -config $BASEDIR/target_config.json --insecure $OPTS >> /dev/null 2>&1 &
-    sleep 3
+    sleep 10
 }
 
 # stop_gnmi_target <gnmi_port>
 stop_gnmi_target() {
     echo "--- Stop TARGET"
-    pkill -f "$(go env GOPATH)/bin/gnmi_target -bind_address :$1"
+    pkill -f "gnmi_target -bind_address :$1"
 }
 
 # start_oc_config_validate <gnmi_port>

--- a/oc_config_validate/docker/Dockerfile
+++ b/oc_config_validate/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-slim-bullseye
+
+RUN apt-get update && apt-get install -y iproute2 telnet iputils-ping
+RUN pip3 install --extra-index-url https://test.pypi.org/simple/ oc-config-validate
+
+WORKDIR /opt/oc_config_validate
+
+VOLUME /opt/oc_config_validate/tests /opt/oc_config_validate/init_configs /opt/oc_config_validate/tests/results
+
+CMD python3 -m oc_config_validate --version

--- a/oc_config_validate/docker/README.md
+++ b/oc_config_validate/docker/README.md
@@ -1,0 +1,53 @@
+# Docker
+
+`oc_config_validate` can be run in a Docker container, using 3 Volumes to share
+files between 3 directories in the container and the host:
+
+ Volume | Path in container
+ ------ | ----------------
+ oc_config_validate_tests | /opt/oc_config_validate/tests
+ oc_config_validate_init_configs | /opt/oc_config_validate/init_configs
+ oc_config_validate_results | /opt/oc_config_validate/results
+
+
+## How to use
+
+ 1. Create the 3 Docker Volumes in your host:
+
+ ```
+ docker volume create oc_config_validate_tests
+ docker volume create oc_config_validate_init_configs
+ docker volume create oc_config_validate_results
+ ```
+
+ 1. Put all your tests and initial configuration files in the volumes.
+
+    * Your test files MUST reference the init_config files as
+     `init_configs/<file>.json`.
+
+ 1. Get the Docker image and test it can reach the gNMI target:
+
+   ```
+    docker run -it \
+      -v oc_config_validate_tests:/opt/oc_config_validate/tests \
+      -v oc_config_validate_init_configs:/opt/oc_config_validate/init_configs \
+      -v oc_config_validate_results:/opt/oc_config_validate/results \
+      joseignaciotamayo/oc_config_validate:latest /bin/bash
+   ```
+
+   You will likely need to edit your host configuration to allow communication
+   between the container and the gNMI Target. Use tools like `ping`, `telnet`
+   and `ip route` in the container to verify connectivity.
+
+ 1. Run `oc_config_validate` with tests and resultss files, using the relevant
+    options. E.g.:
+
+   ```
+    docker run -it \
+      -v oc_config_validate_tests:/opt/oc_config_validate/tests \
+      -v oc_config_validate_init_configs:/opt/oc_config_validate/init_configs \
+      -v oc_config_validate_results:/opt/oc_config_validate/results \
+      joseignaciotamayo/oc_config_validate:latest \
+       python3 -m oc_config_validate --tests_file tests/system.yaml \
+        --results_file results/system.json --stop_on_error --log_gnmi
+   ```


### PR DESCRIPTION
This allows to easily run the Demo without installing anything on the 
host.

Also, this could facilitate the use of oc_config_validate in 
Docker-based environments.

The Demo script was updated to run correctly inside a container