### PR TITLE
Make the basic testacases atomic.

### DIFF
--- a/oc_config_validate/demo/results.json
+++ b/oc_config_validate/demo/results.json
@@ -1,13 +1,12 @@
 {
   "test_target": "localhost:9339",
-  "oc_models": [],
   "description": "Example of test profile for oc_config_validator",
   "labels": [
     "FOO",
     "BAR"
   ],
-  "start_time_sec": 1645041042.7153726,
-  "end_time_sec": 1645041053.3374372,
+  "start_time_sec": 1654064882.4712753,
+  "end_time_sec": 1654064888.912269,
   "results": [
     {
       "test_name": "Get System Config",
@@ -18,7 +17,7 @@
           "test_case": "test0200",
           "test_class": "Get",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -31,10 +30,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetJsonCheck",
           "test_class": "GetJsonCheck",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -47,10 +46,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetJsonCheck",
           "test_class": "GetJsonCheck",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -63,10 +62,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -79,10 +78,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -95,10 +94,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -111,13 +110,13 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 53, in inner\n    method(self, *args, **kw)\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 50, in test0200\n    self.assertTrue(cmp,  diff)\nAssertionError: False is not true : key openconfig-interfaces:enabled: got 'True', wanted 'False'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 50, in testGetCompare\n    self.assertTrue(cmp,  diff)\nAssertionError: False is not true : key openconfig-interfaces:enabled: got 'True', wanted 'False'\n"
         }
       ]
     },
@@ -127,10 +126,10 @@
       "duration_sec": 2,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testSetUpdate",
           "test_class": "SetUpdate",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041042,
+          "start_time_sec": 1654064882,
           "duration_sec": 2,
           "result": "PASS",
           "log": ""
@@ -143,10 +142,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041044,
+          "start_time_sec": 1654064884,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -159,10 +158,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041044,
+          "start_time_sec": 1654064884,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -175,27 +174,27 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041044,
+          "start_time_sec": 1654064884,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 53, in inner\n    method(self, *args, **kw)\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 115, in test0200\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:domain-name: got 'foo.bar.com', wanted 'la.la.la.com'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 117, in testGetJsonCheckCompare\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:domain-name: got 'foo.bar.com', wanted 'la.la.la.com'\n"
         }
       ]
     },
     {
       "test_name": "Set timezone with a valid Json blob",
       "success": true,
-      "duration_sec": 3,
+      "duration_sec": 2,
       "results": [
         {
-          "test_case": "test0100",
+          "test_case": "testJsonCheckSetUpdate",
           "test_class": "JsonCheckSetUpdate",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041044,
-          "duration_sec": 3,
+          "start_time_sec": 1654064884,
+          "duration_sec": 2,
           "result": "PASS",
           "log": ""
         }
@@ -207,87 +206,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test0200",
+          "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041047,
-          "duration_sec": 0,
-          "result": "PASS",
-          "log": ""
-        }
-      ]
-    },
-    {
-      "test_name": "Set timezone with a valid Json blob",
-      "success": true,
-      "duration_sec": 2,
-      "results": [
-        {
-          "test_case": "test0000",
-          "test_class": "JsonCheck",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041047,
-          "duration_sec": 0,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0100",
-          "test_class": "JsonCheck",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041047,
-          "duration_sec": 2,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0200",
-          "test_class": "JsonCheck",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041049,
-          "duration_sec": 0,
-          "result": "PASS",
-          "log": ""
-        }
-      ]
-    },
-    {
-      "test_name": "Set timezone with a valid Json blob, and check it is Zurich",
-      "success": true,
-      "duration_sec": 2,
-      "results": [
-        {
-          "test_case": "test0000",
-          "test_class": "JsonCheckCompare",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041049,
-          "duration_sec": 0,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0100",
-          "test_class": "JsonCheckCompare",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041049,
-          "duration_sec": 2,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0200",
-          "test_class": "JsonCheckCompare",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041051,
-          "duration_sec": 0,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0300",
-          "test_class": "JsonCheckCompare",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041051,
+          "start_time_sec": 1654064886,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -300,36 +222,18 @@
       "duration_sec": 2,
       "results": [
         {
-          "test_case": "test0100",
+          "test_case": "testSetConfigCheckState",
           "test_class": "SetConfigCheckState",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041051,
+          "start_time_sec": 1654064886,
           "duration_sec": 2,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0200",
-          "test_class": "SetConfigCheckState",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041053,
-          "duration_sec": 0,
-          "result": "PASS",
-          "log": ""
-        },
-        {
-          "test_case": "test0300",
-          "test_class": "SetConfigCheckState",
-          "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1645041053,
-          "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 53, in inner\n    method(self, *args, **kw)\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/config_state.py\", line 70, in test0300\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:timezone-name: got 'Europe/Stockholm', wanted 'Europe/Paris'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/usr/local/google/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/config_state.py\", line 68, in testSetConfigCheckState\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:timezone-name: got 'Europe/Stockholm', wanted 'Europe/Paris'\n"
         }
       ]
     }
   ],
-  "tests_pass": 13,
-  "tests_total": 16,
+  "tests_pass": 11,
+  "tests_total": 14,
   "tests_fail": 3
 }

--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -71,7 +71,7 @@
 
 ### Module setget
 
- *  `setget.JsonCheck`
+ *  `setget.SetGetJsonCheck`
 
     Sends gNMI Set and later Get, schema-checking the JSON-IETF value.
 
@@ -88,7 +88,7 @@
      *  `retries`: Optional. Number of retries if the assertion fails.
      *  `retry_delay`: Optional. Delay, in seconds, between retries. Default 10.
 
- *  `setget.JsonCheckCompare`
+ *  `setget.SetGetJsonCheckCompare`
 
     Does what setget.JsonCheck does, but also compares the JSON Get reply.
 

--- a/oc_config_validate/oc_config_validate/testcases/config_state.py
+++ b/oc_config_validate/oc_config_validate/testcases/config_state.py
@@ -26,8 +26,8 @@ class SetConfigCheckState(testbase.TestCase):
     json_value = None
     model = ""
 
-    def test0100(self):
-        """gNMI Set on /config"""
+    @testbase.retryAssertionError
+    def testSetConfigCheckState(self):
         self.assertArgs(["xpath", "model", "json_value"])
         xpath = self.xpath.rstrip("/") + "/config"
         self.assertXpath(xpath)
@@ -37,14 +37,13 @@ class SetConfigCheckState(testbase.TestCase):
         model = schema.ocContainerFromPath(self.model, xpath)
         self.assertJsonModel(json.dumps(self.json_value), model,
                              "JSON value to Set does not match the model")
+
+        # gNMI Set on /config
         self.assertTrue(
             self.gNMISetUpdate(xpath, self.json_value),
             "gNMI Set did not succeed.")
 
-    @testbase.retryAssertionError
-    def test0200(self):
-        """gNMI Get on /config"""
-        self.assertArgs(["xpath", "model", "json_value"])
+        # gNMI Get on /config
         xpath = self.xpath.rstrip("/") + "/config"
         resp_val = self.gNMIGetJson(xpath)
         model = schema.ocContainerFromPath(self.model, xpath)
@@ -54,10 +53,7 @@ class SetConfigCheckState(testbase.TestCase):
         cmp, diff = target.intersectCmp(self.json_value, got)
         self.assertTrue(cmp, diff)
 
-    @testbase.retryAssertionError
-    def test0300(self):
-        """gNMI Get on /state"""
-        self.assertArgs(["xpath", "model", "json_value"])
+        # gNMI Get on /state
         xpath = self.xpath.rstrip("/") + "/state"
         resp = self.gNMIGet(xpath)
         self.assertIsNotNone(resp, "No gNMI GET response")
@@ -87,30 +83,27 @@ class DeleteConfigCheckState(testbase.TestCase):
     """
     xpath = ""
 
-    def test0100(self):
-        """gNMI Get on /config to verify it is configured"""
+    @testbase.retryAssertionError
+    def testDeleteConfigCheckState(self):
         self.assertArgs(["xpath"])
         self.assertXpath(self.xpath)
+
+        # gNMI Get on /config to verify it is configured
         self.assertTrue(
             self.gNMIGet(self.xpath.rstrip("/") + "/config"),
             "There is no configured /config container for the xpath.")
 
-    def test0200(self):
-        """gNMI Delete on the xpath"""
+        # gNMI Delete on the xpath
         self.assertTrue(
             self.gNMISetDelete(self.xpath.rstrip("/")),
             "gNMI Delete did not succeed.")
 
-    @testbase.retryAssertionError
-    def test0300(self):
-        """gNMI Get on /config to verify it is deleted"""
+        # gNMI Get on /config to verify it is deleted
         self.assertFalse(
             self.gNMIGet(self.xpath.rstrip("/") + "/config"),
             "There is still a /config container for the xpath.")
 
-    @testbase.retryAssertionError
-    def test0400(self):
-        """gNMI Get on /state to verify it is deleted"""
+        # gNMI Get on /state to verify it is deleted
         self.assertFalse(
             self.gNMIGet(self.xpath.rstrip("/") + "/state"),
             "There is still a /state container for the xpath.")

--- a/oc_config_validate/oc_config_validate/testcases/get.py
+++ b/oc_config_validate/oc_config_validate/testcases/get.py
@@ -36,7 +36,7 @@ class GetCompare(testbase.TestCase):
     want = ""
 
     @testbase.retryAssertionError
-    def test0200(self):
+    def testGetCompare(self):
         """"""
         self.assertArgs(["xpath", "want"])
         self.assertXpath(self.xpath)
@@ -66,7 +66,7 @@ class GetJsonCheck(testbase.TestCase):
     model = ""
 
     @testbase.retryAssertionError
-    def test0200(self):
+    def testGetJsonCheck(self):
         """"""
         self.assertArgs(["xpath", "model"])
         self.assertXpath(self.xpath)
@@ -97,7 +97,7 @@ class GetJsonCheckCompare(testbase.TestCase):
     want_json = None
 
     @testbase.retryAssertionError
-    def test0200(self):
+    def testGetJsonCheckCompare(self):
         """"""
         self.assertArgs(["xpath", "want_json", "model"])
         self.assertXpath(self.xpath)

--- a/oc_config_validate/oc_config_validate/testcases/set.py
+++ b/oc_config_validate/oc_config_validate/testcases/set.py
@@ -17,7 +17,7 @@ class SetUpdate(testbase.TestCase):
     xpath = ""
     value = None
 
-    def test0200(self):
+    def testSetUpdate(self):
         """"""
         self.assertArgs(["xpath", "value"])
         self.assertXpath(self.xpath)
@@ -35,7 +35,7 @@ class SetDelete(testbase.TestCase):
     """
     xpath = ""
 
-    def test0200(self):
+    def testSetDelete(self):
         """"""
         self.assertArgs(["xpath"])
         self.assertXpath(self.xpath)
@@ -59,7 +59,7 @@ class JsonCheckSetUpdate(testbase.TestCase):
     json_value = None
     model = ""
 
-    def test0100(self):
+    def testJsonCheckSetUpdate(self):
         """"""
         self.assertArgs(["xpath", "json_value", "model", ])
         self.assertXpath(self.xpath)


### PR DESCRIPTION
Based on usage, it makes more sense for the basic testcases to be atomic, one single test method that reflects better the sequential nature of the tests.