### PR TITLE
allow for SONiC style path root

### DIFF
--- a/utils/xpath/xpath.go
+++ b/utils/xpath/xpath.go
@@ -26,7 +26,7 @@ var (
 	idPattern = `[a-zA-Z_][a-zA-Z\d\_\-\.]*`
 	// YANG identifiers must follow RFC 6020:
 	// https://tools.ietf.org/html/rfc6020#section-6.2.
-	idRe = regexp.MustCompile(`^` + idPattern + `$`)
+	idRe = regexp.MustCompile(`^(?:`+idPattern+`:)?` + idPattern + `$`)
 	// The sting representation of List key value pairs must follow the
 	// following pattern: [key=value], where key is the List key leaf name,
 	// and value is the string representation of key leaf value.


### PR DESCRIPTION
When accessing SONiC openconfig paths SONiC requires the `openconfig-*: ` prefix.  The regex change doesn't require that but allows for the `:` to denote it.  

== GetRequest:
 prefix: <
  origin: "OC-YANG"
>
path: <
  elem: <
    name: **"openconfig-interfaces:interfaces"**
  >
  elem: <
    name: "interface"
    key: <
      key: "name"
      value: "Ethernet0"
    >
  >
>
encoding: JSON_IETF