### PR TITLE
[oc_config_validate] Raise Exception when failed to load init config

### DIFF
--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -247,9 +247,11 @@ def main():  # noqa
     if args["init_config_file"]:
         ctx.init_configs.append(context.InitConfig(args["init_config_file"],
                                                    args["init_config_xpath"]))
-    if not runner.setInitConfigs(ctx, tgt,
-                                 stop_on_error=args["stop_on_error"]):
-        sys.exit(1)
+    try:
+        runner.setInitConfigs(ctx, tgt,
+                              stop_on_error=args["stop_on_error"])
+    except runner.InitConfigError as err:
+        sys.exit("Unable to apply init config(s): %s" % err)
 
     start_t = time.time()
     results = runner.runTests(ctx, tgt, stop_on_error=args["stop_on_error"])

--- a/oc_config_validate/oc_config_validate/testbase.py
+++ b/oc_config_validate/oc_config_validate/testbase.py
@@ -266,7 +266,7 @@ class TestCase(unittest.case.TestCase):
                     (timestamp, schema.typedValueToPython(u.val)))
         return stream_updates
 
-    @ classmethod
+    @classmethod
     def insertArgs(cls, test: unittest.TestCase, args: Dict[str, Any]):
         """Insert test arguments to the test.
 
@@ -278,7 +278,7 @@ class TestCase(unittest.case.TestCase):
         for key, value in args.items():
             setattr(test, key, value)
 
-    @ classmethod
+    @classmethod
     def insertTarget(cls,
                      test: unittest.TestCase,
                      tgt: target.TestTarget):


### PR DESCRIPTION
Instead of a binary result, failing to apply an init config raises an Exception that can be caught and better exposed on calling methods.