### PR TITLE
oc_config_validate Stream Subscription model-based tests

### DIFF
--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -344,26 +344,25 @@ Args:
  *  **values_type**: Python type of the values of the Updates.
 
 
-####  `telemetry_once.CheckStateLeafs`
+####  `telemetry_once.CheckLeafs`
 
 In addition to the default checks of the module, this test checks that the
-subscription to */state* containers updates all leafs.
+subscription to containers updates all leafs.
 
-This test subscribes only xpaths of */state* containers. It renders the
-  corresponding OC model and lists all paths to the downstream Leafs. The
-  Update paths received in the Subscription reply are checked against the
-  Leafs of the Model (Update paths must match an OC Model Leaf).
+This test subscribes only xpaths of containers. It renders the
+corresponding OC model and lists all paths to the downstream Leafs. The
+Update paths received in the Subscription reply are checked against the
+Leafs of the Model (Update paths must match an OC Model Leaf).
 
 Optionally, use `check_missing_model_paths` to assert that all OC model paths
-  are present in the Updates. Usually, the Subscription replies might not
-  have all Leaf paths that the OC mode has.
+are present in the Updates. Usually, the Subscription replies might not
+have all Leaf paths that the OC mode has.
 
 > This check does NOT check the type of the values returned.
 
 Args:
- *  **xpaths**: List of /state gNMI paths to subscribe to.
-     If the paths do not end in '/state', it will be appended.
-     Paths can contain wildcard '*'.
+ *  **xpaths**: List of gNMI paths to subscribe to.
+     Paths can contain wildcards only in keys '*'.
  *  **model**: Python binding class to check the reply against.
  *  *check_missing_model_paths*: If True, it asserts that all OC Model Leaf
      paths are in the received Updates. Defaults to False.
@@ -394,7 +393,6 @@ that the timestamp difference of updates is 15 secs.
 > Use telemetry_once.* for that.
 
 Args:
- *  **xpath**: gNMI path to subscribe to.
  *  **sample_interval**: Seconds interval between Updates
  *  **sample_timeout**: Seconds to keep the Subscription and collect Updates.
  *  *max_timestamp_drift_secs*: Maximum drift for the timestamp(s) in the
@@ -417,4 +415,33 @@ Update path | t0 | t15 | t30 | t45 | t60
 `/<root>/<container>/<leaf3>` | value |       | value |       | value
 
 Args:
+ *  **xpath**: gNMI path to subscribe to. Path can contain wildcards '*'.
  * **update_paths_count**: Number of expected distinct Update paths.
+
+####  `telemetry_sample.CheckLeafs`
+
+In addition to the default checks of the module, this test checks that the
+subscription to a container updates all leafs under it.
+
+It renders the corresponding OC model and lists all paths to the downstream
+Leafs. The Update paths received in the Subscription replies are checked
+against the Leafs of the model (all Update paths must match an OC model Leaf).
+
+ E.g:
+ Suppose the test is subscribing to an xpath `/<root>/<container>/state`, with
+ 15 secs interval for 65 secs. After collecting subscription responses for 65
+ secs, the test checks that all Update paths are valid in the given OC model,
+ and that there are updates for all paths.
+
+ Update path | t0 | t15 | t30 | t45 | t60
+ ----------- | -- | --- | --- | --- | ---
+ `/<root>/<container>/state/<leaf1>` | value | value | value | value | value
+ `/<root>/<container>/state/<leaf2>` |       | value | value |       |
+ `/<root>/<container>/state/<leaf3>` | value |       | value |       | value
+
+> This check does NOT check the type of the values returned.
+
+Args:
+ *  **xpath**: gNMI path to subscribe to.
+    Can contain wildcards only in keys '*'.
+*  **model**: Python binding class to check the replies against.

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
@@ -48,7 +48,7 @@ class CountUpdatesCheckType(SubsOnceTestCase):
     """Subscribes ONCE and checks the returned updates and their value types.
 
     Args:
-        xpaths: List of /state gNMI paths to subscribe to.
+        xpaths: List of gNMI paths to subscribe to. Can contain wildcards.
         updates_count: Number of expected Update messages.
         values_type: Python type of the values of the Updates.
 
@@ -76,14 +76,14 @@ class CountUpdatesCheckType(SubsOnceTestCase):
             f"Expected {self.updates_count} Updates, got: {updates}")
 
 
-class CheckStateLeafs(SubsOnceTestCase):
-    """Subscribes ONCE and checks the updates againts the state OC model.
+class CheckLeafs(SubsOnceTestCase):
+    """Subscribes ONCE and checks the updates againts the OC model.
 
     All arguments are read from the Test YAML description.
 
     Args:
-        xpaths: List of /state gNMI paths to subscribe to.
-                If the paths do not end in ''/state', it will be added.
+        xpaths: List of gNMI paths to subscribe to. The paths can contain
+          wildcards only in the keys.
         model: Python binding class to check the JSON reply against.
         check_missing_model_paths: If True, missing OC Model leaf paths in the
                                    Updates replies are checked.
@@ -95,17 +95,12 @@ class CheckStateLeafs(SubsOnceTestCase):
         """"""
         self.assertArgs(["xpaths", "model"])
 
-        self.subscribeOnce()
-
         want_paths = []
         for xpath in self.xpaths:
-            # Ensure the path ends in /state.
-            elems = xpath.split("/")
-            if elems[-1] != "state":
-                elems.append("state")
-            xpath = "/".join(elems)
             self.assertModelXpath(self.model, xpath)
             want_paths.extend(schema.ocLeafsPaths(self.model, xpath))
+
+        self.subscribeOnce()
 
         got_updates = []
         for n in self.responses:

--- a/oc_config_validate/tests/ap_telemetry.yaml
+++ b/oc_config_validate/tests/ap_telemetry.yaml
@@ -22,7 +22,7 @@ tests:
     notifications_count: 1
 
 - !TestCase
-  name: "Get RADIUS Couners"
+  name: "Count RADIUS Counters Once"
   class_name: telemetry_once.CountUpdatesCheckType
   args:
     xpaths: ["/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"]
@@ -30,29 +30,29 @@ tests:
     updates_count: 4
 
 - !TestCase
-  name: "Get Radios State"
-  class_name: telemetry_once.CheckStateLeafs
+  name: "Check Radios State Once"
+  class_name: telemetry_once.CheckLeafs
   args:
     xpaths: ["/access-points/access-point[hostname=*]/radios/radio[id=*][operating-frequency=*]/state"]
     model: "wifi.openconfig_access_points"
     max_timestamp_drift_secs: 5
 
 - !TestCase
-  name: "Get MAC SSIDs"
-  class_name: telemetry_once.CheckStateLeafs
+  name: "Check MAC SSIDs Once"
+  class_name: telemetry_once.CheckLeafs
   args:
     xpaths: ["/access-points/access-point[hostname=*]/ssids/ssid[name=*]/bssids/bssid[radio-id=*][bssid=*]/state"]
     model: "wifi.openconfig_access_points"
 
 - !TestCase
-  name: "Get RADIUS Counters"
-  class_name: telemetry_once.CheckStateLeafs
+  name: "Check RADIUS Counters Once"
+  class_name: telemetry_once.CheckLeafs
   args:
-    xpaths: ["/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state"]
+    xpaths: ["/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"]
     model: "wifi.openconfig_access_points"
 
 - !TestCase
-  name: "Get Radios State"
+  name: "Count Radios State Sampling"
   class_name: telemetry_sample.CountUpdates
   args:
     xpath: "/access-points/access-point[hostname=*]/radios/radio[id=*][operating-frequency=FREQ_2GHZ]/state"
@@ -61,10 +61,28 @@ tests:
     update_paths_count: 6
 
 - !TestCase
-  name: "Get RADIUS Couners"
+  name: "Check Radios State Sampling"
+  class_name: telemetry_sample.CheckLeafs
+  args:
+    xpath: "/access-points/access-point[hostname=*]/radios/radio[id=*][operating-frequency=FREQ_2GHZ]/state"
+    sample_interval: 30
+    sample_timeout: 70
+    model: "wifi.openconfig_access_points"
+
+- !TestCase
+  name: "Count RADIUS Counters Sampling"
   class_name: telemetry_sample.CountUpdates
   args:
     xpath: "/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"
     sample_interval: 30
     sample_timeout: 70
     update_paths_count: 4
+
+- !TestCase
+  name: "Check RADIUS Counters Sampling"
+  class_name: telemetry_sample.CheckLeafs
+  args:
+    xpath: "/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"
+    sample_interval: 30
+    sample_timeout: 70
+    model: "wifi.openconfig_access_points"


### PR DESCRIPTION
Add testcases to oc_config_validate to test Stream Subscriptions rendering the path in an OC Model.

This does not need to tell the number of expected updates, but an OC model represented by the path, and all Leafs are checked.