### PR TITLE
[oc_config_validate] Improve Subscription tests with multiple paths

### DIFF
--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -313,6 +313,8 @@ By default, the tests do 5 retries, with 15 seconds delay, if the assertion fail
 
 Uses gNMI Subscribe messages, of type ONCE.
 
+This testcase supports sending multiple xpaths in the gNMI Subscribe request.
+
 Optionally, every Update messages can have its timestamp value checked
   against the local time when the Subscription message was sent. The absolute
   time drift is compared against a max value in secs.

--- a/oc_config_validate/oc_config_validate/runner.py
+++ b/oc_config_validate/oc_config_validate/runner.py
@@ -228,7 +228,7 @@ def setInitConfigs(ctx: context.TestContext,
                          "applied at {init_config.xpath}")
         except (IOError, json.JSONDecodeError, target.BaseError) as err:
             msg = (f"Unable to set configuration '{init_config.filename}' "
-                   "at '{init_config.xpath}': {err}")
+                   f"at '{init_config.xpath}': {err}")
             if stop_on_error:
                 raise InitConfigError(msg) from err
             logging.error(msg)

--- a/oc_config_validate/oc_config_validate/target.py
+++ b/oc_config_validate/oc_config_validate/target.py
@@ -25,7 +25,7 @@ import json
 import logging
 import ssl
 import time
-from typing import Any, Iterator, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import grpc
 from grpc._channel import _InactiveRpcError, _MultiThreadedRendezvous
@@ -278,7 +278,7 @@ class TestTarget():
         self.gNMISetUpdate(xpath, json_data)
 
     def _gNMISubscribe(self,
-                       requests: Iterator[gnmi_pb2.SubscribeRequest],
+                       request: gnmi_pb2.SubscribeRequest,
                        timeout: int = 30,
                        check_sync_response: bool = False
                        ) -> List[gnmi_pb2.Notification]:
@@ -308,7 +308,7 @@ class TestTarget():
         got_sync_response = False
         try:
             for resp in self.stub.Subscribe(
-                    requests, timeout=timeout, metadata=auth):
+                    iter([request]), timeout=timeout, metadata=auth):
                 if resp.sync_response:
                     got_sync_response = True
                 elif resp.update:
@@ -336,8 +336,8 @@ class TestTarget():
         Returns:
             A list of gnmi_pb2.Notification objects received.
         """
-        requests = schema.gNMISubscriptionOnceRequests(xpaths)
-        return self._gNMISubscribe(requests)
+        request = schema.gNMISubscriptionOnceRequest(xpaths)
+        return self._gNMISubscribe(request)
 
     def gNMISubsStreamSample(self, xpath: str, sample_interval: int,
                              timeout: int) -> List[gnmi_pb2.Notification]:
@@ -353,9 +353,9 @@ class TestTarget():
             A list of gnmi_pb2.Notification objects received.
 
         """
-        requests = schema.gNMISubscriptionStreamSampleRequests(
+        request = schema.gNMISubscriptionStreamSampleRequest(
             [xpath], sample_interval)
-        return self._gNMISubscribe(requests, timeout=timeout)
+        return self._gNMISubscribe(request, timeout=timeout)
 
     def validate(self):
         """Ensures the Target is defined appropriately.

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
@@ -66,6 +66,10 @@ class CountUpdatesCheckType(SubsOnceTestCase):
         for n in self.responses:
             updates += len(n.update)
             for u in n.update:
+                got_path = schema.pathToString(u.path)
+                self.assertTrue(
+                    schema.isPathInRequestedPaths(got_path, self.xpaths),
+                    f"Unexpected update path {got_path} for subscription")
                 self.assertTrue(
                     u.val.HasField(self.values_type),
                     f"Value of Update {schema.pathToString(u.path)} "
@@ -115,9 +119,8 @@ class CheckLeafs(SubsOnceTestCase):
             got_path = schema.pathToString(u.path)
             got_paths.append(got_path)
             self.assertTrue(
-                schema.isPathIn(got_path, want_paths),
-                f"Unexpected update path {got_path} for OC model {self.model},"
-                f"expected {want_paths}")
+                schema.isPathInRequestedPaths(got_path, want_paths),
+                f"Unexpected update path {got_path} for subscription")
 
         if self.check_missing_model_paths:
             for want_path in want_paths:

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py
@@ -94,6 +94,7 @@ class CountUpdates(SubsSampleTestCase):
             got_paths, self.update_paths_count,
             f"Expected {self.update_paths_count} Update paths, "
             f"got: {got_paths}")
+<<<<<<< HEAD
 
 
 class CheckLeafs(SubsSampleTestCase):
@@ -121,9 +122,8 @@ class CheckLeafs(SubsSampleTestCase):
         got_paths = len(self.responses)
         self.assertGreater(got_paths, 0,
                            "There are no Update replies to the Subscription")
-        if self.responses:
+       if self.responses:
             for path, _ in self.responses.items():
                 self.assertTrue(
-                    schema.isPathIn(path, want_paths),
-                    f"Unexpected update path {path} for subscription to"
-                    f" {self.xpath} with model {self.model}")
+                    schema.isPathInRequestedPaths(path, [self.xpath]),
+                    f"Unexpected update path {path} for subscription")

--- a/oc_config_validate/py_tests/test_schema.py
+++ b/oc_config_validate/py_tests/test_schema.py
@@ -138,5 +138,54 @@ class TestParsePaths(unittest.TestCase):
             self.assertEqual(path_str, schema.pathToString(got_obj), name)
 
 
+class TestisPathInRequestedPathsRequestedPaths(unittest.TestCase):
+    """Test for isPathInRequestedPaths."""
+
+    @parameterized.expand([
+        ("_in", "/interfaces/interface[name=ethernet1/2]/state", True),
+        ("_deep_in",
+         "/interfaces/interface[name=ethernet1/2]/state/counters/out-errors",
+         True),
+        ("_not_int",
+         "/interfaces/interface[name=ethernet1/2]/config/name", False),
+    ])
+    def test_isPathInRequestedPathsRequestedPaths_singleReq(self, name, xpath,
+                                                            want):
+        request_xpaths = ["/interfaces/interface[name=ethernet1/2]/state"]
+        self.assertEqual(schema.isPathInRequestedPaths(
+            xpath, request_xpaths), want)
+
+    @parameterized.expand([
+        ("_in", "/interfaces/interface[name=ethernet1/0]/state", True),
+        ("_deep_in",
+         "/interfaces/interface[name=ethernet1/1]/state/counters/out-errors",
+         True),
+        ("_not_int",
+         "/interfaces/interface[name=ethernet1/2]/config/name", False),
+    ])
+    def test_isPathInRequestedPathsRequestedPaths_singleWcardReq(self, name,
+                                                                 xpath, want):
+        request_xpaths = ["/interfaces/interface[name=*]/state"]
+        self.assertEqual(schema.isPathInRequestedPaths(
+            xpath, request_xpaths), want)
+
+    @parameterized.expand([
+        ("_in", "/interfaces/interface[name=ethernet1/0][id=0]/state", True),
+        ("_deep_in",
+         "/interfaces/interface[id=1][name=1/1]/state/counters/out-errors",
+         True),
+        ("_not_int",
+         "/interfaces/interface[name=ethernet1/2]/config/state", False),
+    ])
+    def test_isPathInRequestedPathsRequestedPaths_manyKeysReq(self, name,
+                                                              xpath, want):
+        request_xpaths = ["/interfaces/interface[name=*][id=*]/state"]
+        self.assertEqual(schema.isPathInRequestedPaths(
+            xpath, request_xpaths), want)
+        request_xpaths = ["/interfaces/interface[id=*][name=*]/state"]
+        self.assertEqual(schema.isPathInRequestedPaths(
+            xpath, request_xpaths), want)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Send a single SubscribeRequest with many paths is sent.
* Do path inclusion comparison deal with sorted keys.
* Compare Subscription Update paths with requested paths.
* Check paths in Subscription tests.