### PR TITLE
Publish and use Python Package from PyPi.

### DIFF
--- a/oc_config_validate/CONTRIBUTING.md
+++ b/oc_config_validate/CONTRIBUTING.md
@@ -103,12 +103,12 @@ Place your testing code in `py_tests/test_*.py` and run the tests with `python3 
 
 ### Releasing the `oc_config_validate` PyPi package
 
-1. Create a cleared virtual environment with `virtualenv --clear <name>` and activate it with `source <name>/bin/activate`.
+1. Create a cleared virtual environment with `virtualenv --clear ${NAME?}` and activate it with `source ${NAME?}/bin/activate`.
 1. Install the `build` and `twine` packages with `pip3 install build twine`.
 1. Call `python3 -m build` to build the packages.
-1. Verify that the package installs correctly, with `pip3 install dist/oc_config_validate-<version>.tar.gz` and `pip3 show oc_config_validate`.
+1. Verify that the package installs correctly, with `pip3 install dist/oc_config_validate-${VERSION?}.tar.gz` and `pip3 show oc_config_validate`.
 1. Verify that the package runs correctly, with `python3 -I -m oc_config_validate --version`.
-1. Upload the latest packages to TestPyPi with `python3 -m twine upload --verbose --repository testpypi --skip-existing dist/*`.
+1. Upload the latest packages to PyPi with `python3 -m twine upload --verbose dist/oc_config_validate-${VERSION?}*`.
 
 ### Releasing the `oc_config_validate` Docker images
 
@@ -129,4 +129,3 @@ The Docker images take the latest code from the `master` branch of the Git repos
    sudo docker push joseignaciotamayo/oc_config_validate:<version>
    sudo docker push joseignaciotamayo/oc_config_validate:latest
    ```
-

--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -34,10 +34,10 @@ looking for:
     source venv/bin/activate
     ```
 
-1. Install from TestPypi
+1. Install from Pypi
 
     ```
-    pip3 install --extra-index-url https://test.pypi.org/simple/ oc-config-validate
+    pip3 install oc-config-validate
     ```
 
 1. Check it is all working as expected:

--- a/oc_config_validate/demo/Dockerfile
+++ b/oc_config_validate/demo/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim-bullseye
 
 RUN apt-get update
 RUN apt-get install -y procps
-RUN pip3 install --extra-index-url https://test.pypi.org/simple/ oc-config-validate
+RUN pip3 install oc-config-validate
 
 WORKDIR /opt/oc_config_validate
 

--- a/oc_config_validate/docker/Dockerfile
+++ b/oc_config_validate/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim-bullseye
 
 RUN apt-get update && apt-get install -y iproute2 iputils-ping ncat
-RUN pip3 install --extra-index-url https://test.pypi.org/simple/ oc-config-validate
+RUN pip3 install oc-config-validate
 
 WORKDIR /opt/oc_config_validate
 

--- a/oc_config_validate/setup.cfg
+++ b/oc_config_validate/setup.cfg
@@ -4,6 +4,9 @@ version = attr: oc_config_validate.__version__
 description = Validate OpenConfig-based configuration of devices.
 long_description_content_type = text/markdown
 long_description = file: README.md
+license = Apache License, Version 2.0
+author = Jose Ignacio Tamayo, Xavier Contreras Acevedo
+author_email = jose.ignacio.tamayo@gmail.com, xavierc@google.com
 url = https://github.com/google/gnxi/oc_config_validate
 classifiers =
    Programming Language :: Python :: 3


### PR DESCRIPTION
No longer use TestPyPi, which is intended only to develop and test the package publishing process.