### PR TITLE
Set explicit dependency on pyangbind 0.8.2

### DIFF
--- a/oc_config_validate/CONTRIBUTING.md
+++ b/oc_config_validate/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Place your testing code in `py_tests/test_*.py` and run the tests with `python3 
 
 ### Releasing the `oc_config_validate` Docker images
 
-The Docker images take the latest code from the `master` branch of the Git repository.
+> The Docker images are built taking the latest version of `oc_config_validate` from PyPi.
 
 1. Create a Docker Image for the latest version of `oc_config_validate`, tagged with the version number and `latest`.
 

--- a/oc_config_validate/requirements.txt
+++ b/oc_config_validate/requirements.txt
@@ -5,7 +5,7 @@ grpcio-tools
 isort
 parameterized
 pyang
-pyangbind
+pyangbind<=0.8.2
 pycodestyle
 pyflakes
 pylama

--- a/oc_config_validate/setup.cfg
+++ b/oc_config_validate/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     grpcio
     grpcio-tools
     pyang
-    pyangbind
+    pyangbind>=0.8.2
     PyYAML
     retry
 packages = find:


### PR DESCRIPTION
The oc-models bindings were made with pyangbind 0.8.2, and this version or older is needed for it to work.