### PR TITLE
Indicate that the code needs pyangbind<0.8.3

### DIFF
--- a/oc_config_validate/requirements.txt
+++ b/oc_config_validate/requirements.txt
@@ -5,7 +5,7 @@ grpcio-tools
 isort
 parameterized
 pyang
-pyangbind
+pyangbind==0.8.2
 pycodestyle
 pyflakes
 pylama


### PR DESCRIPTION
The bindings in oc_config_validate break with pyangbind>=0.8.3, due to https://github.com/robshakir/pyangbind/pull/297 (the current bindings import `bitarray`, which pyangbind >= 0.8.3 removed).

This commit enforces a dependency on the pyangbind version for the current code to work. In a future commit, the bindings and this dependency will be updated.