### PR TITLE
Add a function to convert the running configuration to JSON.

### DIFF
--- a/gnmi/server.go
+++ b/gnmi/server.go
@@ -296,6 +296,17 @@ func (s *Server) toGoStruct(jsonTree map[string]interface{}) (ygot.ValidatedGoSt
 	return goStruct, nil
 }
 
+// ConfigAsJSON takes the current configuration of the running server and
+// returns it in a RFC7951 compliant json string.
+func (s *Server) ConfigAsJSON() (string, error) {
+	return ygot.EmitJSON(s.config, &ygot.EmitJSONConfig{
+		Format: ygot.RFC7951,
+		RFC7951Config: &ygot.RFC7951JSONConfig{
+			AppendModuleName: true,
+		},
+	})
+}
+
 // getGNMIServiceVersion returns a pointer to the gNMI service version string.
 // The method is non-trivial because of the way it is defined in the proto file.
 func getGNMIServiceVersion() (*string, error) {


### PR DESCRIPTION
This pull request adds a method, called `ConfigAsJSON`, to the gnmi server implementation. It is useful for me to be able to save the configuration of the GNMI server in a file using the same format as is used to populate the server.

I am raising this PR purely because this feature would be valuable to me. I do not know if there is a better approach somewhere, so I thought I would raise this to have discussion and perhaps merge this if it seems valuable to others as well.

Thank you for reading and reviewing!