### PR TITLE
Add option to timestamped logs

### DIFF
--- a/oc_config_validate/README.md
+++ b/oc_config_validate/README.md
@@ -116,7 +116,7 @@ looking for:
            [--target_cert_as_root_ca | --root_ca_cert FILE ] \
            [--cert_chain FILE --private_key FILE]
            [-init INIT_CONFIG_FILE -xpath INIT_CONFIG_XPATH] \
-           [--verbose] [--log_gnmi] [--stop_on_error]
+           [--verbose] [--log_gnmi] [--stop_on_error] [--log_timestamp]
     ```
 
     For an example:

--- a/oc_config_validate/demo/run_demo.sh
+++ b/oc_config_validate/demo/run_demo.sh
@@ -77,6 +77,7 @@ start_oc_config_validate() {
         --target "localhost:$1" --tests_file $BASEDIR/${t}_tests.yaml --results_file $BASEDIR/${t}_results.json \
         --init_config_file $BASEDIR/system_hostname_config.json --init_config_xpath "/system/config" \
         --target_cert_as_root_ca \
+        --log_timestamp \
         $OPTS
     done
   }

--- a/oc_config_validate/docker/README.md
+++ b/oc_config_validate/docker/README.md
@@ -49,5 +49,5 @@ files between 3 directories in the container and the host:
       -v oc_config_validate_results:/opt/oc_config_validate/results \
       joseignaciotamayo/oc_config_validate:latest \
        python3 -m oc_config_validate --tests_file tests/system.yaml \
-        --results_file results/system.json --stop_on_error --log_gnmi
+        --results_file results/system.json --stop_on_error --log_gnmi --log_timestamp
    ```

--- a/oc_config_validate/oc_config_validate/__main__.py
+++ b/oc_config_validate/oc_config_validate/__main__.py
@@ -25,8 +25,6 @@ import yaml
 from oc_config_validate import (__version__, context, formatter, runner,
                                 schema, target, testbase)
 
-LOGGING_FORMAT = "%(levelname)s(%(filename)s:%(lineno)d):%(message)s"
-
 
 def createArgsParser() -> argparse.ArgumentParser:
     """Create parser for arguments passed into the program from the CLI.
@@ -160,6 +158,11 @@ def createArgsParser() -> argparse.ArgumentParser:
         action="store_true",
         help="Log the gnmi requests to the tests results.",
     )
+    parser.add_argument(
+        "--log_timestamp",
+        action="store_true",
+        help="Timestamp the log messages."
+    )
     return parser
 
 
@@ -208,11 +211,12 @@ def main():  # noqa
         sys.exit()
 
     if args["verbose"]:
-        # os.environ["GRPC_TRACE"] = "all"
         os.environ["GRPC_VERBOSITY"] = "DEBUG"
     logging.basicConfig(
         level=logging.DEBUG if args["verbose"] else logging.INFO,
-        format=LOGGING_FORMAT)
+        format=(("%(asctime)s>" if args["log_timestamp"] else "") +
+                "%(levelname)s(%(filename)s:%(lineno)d):%(message)s"),
+        datefmt="%X")
 
     try:
         validateArgs(args)

--- a/oc_config_validate/oc_config_validate/target.py
+++ b/oc_config_validate/oc_config_validate/target.py
@@ -113,7 +113,6 @@ class TestTarget():
             self.channel = grpc.insecure_channel(self.address)
         else:
             creds = self._buildCredentials()
-            logging.debug("creds: %s", creds)
             if self.host_tls_override:
                 self.channel = grpc.secure_channel(
                     self.address, creds,


### PR DESCRIPTION
The `--log_timestamp`  option prepends the time to each STDOUT log