### PR TITLE
Review Telemetry testclasses, added UnitTests, added/renamed Tests

### DIFF
--- a/oc_config_validate/.gitignore
+++ b/oc_config_validate/.gitignore
@@ -1,3 +1,4 @@
-/venv/
-/oc_config_validate.egg-info/
-/dist/
+venv/
+oc_config_validate.egg-info/
+dist/
+.pytype/

--- a/oc_config_validate/demo/config_results.json
+++ b/oc_config_validate/demo/config_results.json
@@ -5,8 +5,8 @@
     "FOO",
     "BAR"
   ],
-  "start_time_sec": 1681289912.9265878,
-  "end_time_sec": 1681289923.6248236,
+  "start_time_sec": 1755724163.3086755,
+  "end_time_sec": 1755724180.9333513,
   "results": [
     {
       "test_name": "Get System Config",
@@ -17,7 +17,7 @@
           "test_case": "test0200",
           "test_class": "Get",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289912,
+          "start_time_sec": 1755724163,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -27,14 +27,14 @@
     {
       "test_name": "Check System Config",
       "success": true,
-      "duration_sec": 1,
+      "duration_sec": 0,
       "results": [
         {
           "test_case": "testGetJsonCheck",
           "test_class": "GetJsonCheck",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289912,
-          "duration_sec": 1,
+          "start_time_sec": 1755724163,
+          "duration_sec": 0,
           "result": "PASS",
           "log": ""
         }
@@ -49,7 +49,7 @@
           "test_case": "testGetJsonCheck",
           "test_class": "GetJsonCheck",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289913,
+          "start_time_sec": 1755724163,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -65,7 +65,23 @@
           "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289913,
+          "start_time_sec": 1755724163,
+          "duration_sec": 0,
+          "result": "PASS",
+          "log": ""
+        }
+      ]
+    },
+    {
+      "test_name": "Compare Domain Configured",
+      "success": true,
+      "duration_sec": 0,
+      "results": [
+        {
+          "test_case": "testGetCompare",
+          "test_class": "GetCompare",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724163,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -81,7 +97,7 @@
           "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289913,
+          "start_time_sec": 1755724163,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -97,7 +113,7 @@
           "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289913,
+          "start_time_sec": 1755724163,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -105,7 +121,7 @@
       ]
     },
     {
-      "test_name": "Bad Compare mgmt Interface state JSON",
+      "test_name": "FAIL Compare mgmt Interface state JSON",
       "success": false,
       "duration_sec": 0,
       "results": [
@@ -113,15 +129,15 @@
           "test_case": "testGetCompare",
           "test_class": "GetCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289913,
+          "start_time_sec": 1755724163,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 56, in inner\n    method(self, *args, **kw)\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 49, in testGetCompare\n    self.assertTrue(cmp,  diff)\nAssertionError: False is not true : key openconfig-interfaces:enabled: got 'True', wanted 'False'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 49, in testGetCompare\n    self.assertTrue(cmp,  diff)\nAssertionError: False is not true : key openconfig-interfaces:enabled: got 'True', wanted 'False'\n"
         }
       ]
     },
     {
-      "test_name": "Set Hostname",
+      "test_name": "Update Hostname",
       "success": true,
       "duration_sec": 2,
       "results": [
@@ -129,7 +145,7 @@
           "test_case": "testSetUpdate",
           "test_class": "SetUpdate",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289913,
+          "start_time_sec": 1755724163,
           "duration_sec": 2,
           "result": "PASS",
           "log": ""
@@ -145,7 +161,7 @@
           "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289915,
+          "start_time_sec": 1755724165,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -153,23 +169,23 @@
       ]
     },
     {
-      "test_name": "Bad model to compare System config",
+      "test_name": "Replace System Config",
       "success": true,
-      "duration_sec": 0,
+      "duration_sec": 2,
       "results": [
         {
-          "test_case": "testGetJsonCheckCompare",
-          "test_class": "GetJsonCheckCompare",
+          "test_case": "testSetReplace",
+          "test_class": "SetReplace",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289915,
-          "duration_sec": 0,
+          "start_time_sec": 1755724165,
+          "duration_sec": 2,
           "result": "PASS",
           "log": ""
         }
       ]
     },
     {
-      "test_name": "Bad data to compare System config",
+      "test_name": "FAIL Check System config - model",
       "success": false,
       "duration_sec": 0,
       "results": [
@@ -177,15 +193,31 @@
           "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289915,
+          "start_time_sec": 1755724167,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 56, in inner\n    method(self, *args, **kw)\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 108, in testGetJsonCheckCompare\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:domain-name: got 'foo.bar.com', wanted 'la.la.la.com'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 99, in testGetJsonCheckCompare\n    self.assertModelXpath(self.model, self.xpath)\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 471, in assertModelXpath\n    self.assertTrue(\nAssertionError: False is not true : xpath system/config does not point to a container in model interfaces.openconfig_interfaces: 'openconfig_interfaces' object has no attribute 'system'\n"
         }
       ]
     },
     {
-      "test_name": "Set timezone with a valid Json blob",
+      "test_name": "FAIL Compare System config - data",
+      "success": false,
+      "duration_sec": 0,
+      "results": [
+        {
+          "test_case": "testGetJsonCheckCompare",
+          "test_class": "GetJsonCheckCompare",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724167,
+          "duration_sec": 0,
+          "result": "FAIL",
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/get.py\", line 108, in testGetJsonCheckCompare\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:domain-name: got 'foo.bar.com', wanted 'la.la.la.com'\n"
+        }
+      ]
+    },
+    {
+      "test_name": "Update timezone with a valid Json blob",
       "success": true,
       "duration_sec": 2,
       "results": [
@@ -193,7 +225,7 @@
           "test_case": "testJsonCheckSetUpdate",
           "test_class": "JsonCheckSetUpdate",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289915,
+          "start_time_sec": 1755724167,
           "duration_sec": 2,
           "result": "PASS",
           "log": ""
@@ -203,21 +235,21 @@
     {
       "test_name": "Compare Timezone",
       "success": true,
-      "duration_sec": 0,
+      "duration_sec": 1,
       "results": [
         {
           "test_case": "testGetJsonCheckCompare",
           "test_class": "GetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289917,
-          "duration_sec": 0,
+          "start_time_sec": 1755724169,
+          "duration_sec": 1,
           "result": "PASS",
           "log": ""
         }
       ]
     },
     {
-      "test_name": "Set timezone with a valid Json blob",
+      "test_name": "Update timezone with a valid Json blob",
       "success": true,
       "duration_sec": 2,
       "results": [
@@ -225,7 +257,7 @@
           "test_case": "testSetGetJsonCheck",
           "test_class": "SetGetJsonCheck",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289917,
+          "start_time_sec": 1755724170,
           "duration_sec": 2,
           "result": "PASS",
           "log": ""
@@ -233,7 +265,7 @@
       ]
     },
     {
-      "test_name": "Set timezone with a valid Json blob, and check it is Zurich",
+      "test_name": "Update timezone with a valid Json blob, and check it is Zurich",
       "success": true,
       "duration_sec": 2,
       "results": [
@@ -241,7 +273,7 @@
           "test_case": "testSetGetJsonCheckCompare",
           "test_class": "SetGetJsonCheckCompare",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289919,
+          "start_time_sec": 1755724172,
           "duration_sec": 2,
           "result": "PASS",
           "log": ""
@@ -249,7 +281,7 @@
       ]
     },
     {
-      "test_name": "Bad Set Clock Check State",
+      "test_name": "FAIL Update Clock Check State",
       "success": false,
       "duration_sec": 2,
       "results": [
@@ -257,15 +289,63 @@
           "test_case": "testSetConfigCheckState",
           "test_class": "SetConfigCheckState",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1681289921,
+          "start_time_sec": 1755724174,
           "duration_sec": 2,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/config_state.py\", line 72, in testSetConfigCheckState\n    self._get_check_retry()\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 56, in inner\n    method(self, *args, **kw)\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/config_state.py\", line 64, in _get_check_retry\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:timezone-name: got 'Europe/Stockholm', wanted 'Europe/Paris'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/config_state.py\", line 72, in testSetConfigCheckState\n    self._get_check_retry()\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 55, in inner\n    method(self, *args, **kw)\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/config_state.py\", line 64, in _get_check_retry\n    self.assertTrue(cmp, diff)\nAssertionError: False is not true : key openconfig-system:timezone-name: got 'Europe/Stockholm', wanted 'Europe/Paris'\n"
+        }
+      ]
+    },
+    {
+      "test_name": "FAIL Replace System Config - model",
+      "success": false,
+      "duration_sec": 0,
+      "results": [
+        {
+          "test_case": "testJsonCheckSetReplace",
+          "test_class": "JsonCheckSetReplace",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724176,
+          "duration_sec": 0,
+          "result": "FAIL",
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/set.py\", line 120, in testJsonCheckSetReplace\n    self.assertJsonModel(json.dumps(self.json_value), model,\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 427, in assertJsonModel\n    self.assertTrue(match, \"%s: %s\" % (msg, error))\nAssertionError: False is not true : JSON to Set does not match the model: JSON object contained a key that did not exist (host)\n"
+        }
+      ]
+    },
+    {
+      "test_name": "Replace System Config",
+      "success": true,
+      "duration_sec": 2,
+      "results": [
+        {
+          "test_case": "testSetGetJsonCheck",
+          "test_class": "SetGetJsonCheck",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724176,
+          "duration_sec": 2,
+          "result": "PASS",
+          "log": ""
+        }
+      ]
+    },
+    {
+      "test_name": "Replace and Get System Config",
+      "success": true,
+      "duration_sec": 2,
+      "results": [
+        {
+          "test_case": "testSetGetJsonCheckCompare",
+          "test_class": "SetGetJsonCheckCompare",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724178,
+          "duration_sec": 2,
+          "result": "PASS",
+          "log": ""
         }
       ]
     }
   ],
-  "tests_pass": 13,
-  "tests_total": 16,
-  "tests_fail": 3
+  "tests_pass": 16,
+  "tests_total": 21,
+  "tests_fail": 5
 }

--- a/oc_config_validate/demo/telemetry_results.json
+++ b/oc_config_validate/demo/telemetry_results.json
@@ -5,8 +5,8 @@
     "FOO",
     "BAR"
   ],
-  "start_time_sec": 1683576220.4079309,
-  "end_time_sec": 1683576239.5437305,
+  "start_time_sec": 1755724191.3355515,
+  "end_time_sec": 1755724218.7348504,
   "results": [
     {
       "test_name": "Subscribe ONCE to System String values",
@@ -14,10 +14,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test100",
+          "test_case": "testSubscribeOnce",
           "test_class": "CountUpdatesCheckType",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724191,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -30,13 +30,29 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test100",
-          "test_class": "CheckLeafs",
+          "test_case": "testSubscribeOnce",
+          "test_class": "CheckLeafsFromModel",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724191,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
+        }
+      ]
+    },
+    {
+      "test_name": "Subscribe ONCE to Interfaces Counters",
+      "success": false,
+      "duration_sec": 0,
+      "results": [
+        {
+          "test_case": "testSubscribeOnce",
+          "test_class": "CheckLeafsFromModel",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724191,
+          "duration_sec": 0,
+          "result": "FAIL",
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 159, in testSubscribeOnce\n    self.assertIn(\nAssertionError: '/interfaces/interface[name=mgmt]/state/name' not found in {'/interfaces/interface[name=mgmt]/state/oper-status'} : Missing update path /interfaces/interface[name=mgmt]/state/name for OC model interfaces.openconfig_interfaces, got {'/interfaces/interface[name=mgmt]/state/oper-status'}\n"
         }
       ]
     },
@@ -46,10 +62,10 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test100",
+          "test_case": "testSubscribeOnce",
           "test_class": "CountUpdatesCheckType",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724191,
           "duration_sec": 0,
           "result": "PASS",
           "log": ""
@@ -62,13 +78,13 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test100",
+          "test_case": "testSubscribeOnce",
           "test_class": "CountUpdatesCheckType",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724191,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 63, in test100\n    self.subscribeOnce()\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 41, in subscribeOnce\n    self.assertEqual(\nAssertionError: 1 != 2 : Expected 2 notifications, got 1\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 71, in testSubscribeOnce\n    self.subscribeOnce()\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 49, in subscribeOnce\n    self.assertEqual(\nAssertionError: 1 != 2 : Expected 2 notifications, got 1\n"
         }
       ]
     },
@@ -78,13 +94,13 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test100",
+          "test_case": "testSubscribeOnce",
           "test_class": "CountUpdatesCheckType",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724191,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 73, in test100\n    self.assertTrue(\nAssertionError: False is not true : Value of Update /interfaces/interface[name=mgmt]/state/enabled is not of type string_val: bool_val: true\n\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 77, in testSubscribeOnce\n    self.assertTrue(\nAssertionError: False is not true : Value of Update /interfaces/interface[name=mgmt]/state/oper-status is not of type bool_val: string_val: \"UP\"\n\n"
         }
       ]
     },
@@ -94,29 +110,45 @@
       "duration_sec": 0,
       "results": [
         {
-          "test_case": "test100",
-          "test_class": "CountUpdatesCheckType",
+          "test_case": "testSubscribeOnce",
+          "test_class": "CountUpdatePaths",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724191,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 78, in test100\n    self.assertEqual(\nAssertionError: 3 != 4 : Expected 4 Updates, got: 3\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_once.py\", line 109, in testSubscribeOnce\n    self.assertEqual(\nAssertionError: 3 != 4 : Expected 4 Update paths, got: {'/interfaces/interface[name=FortyGigabitEthernet1/1/2]/state/oper-status', '/interfaces/interface[name=FortyGigabitEthernet1/1/1]/state/oper-status', '/interfaces/interface[name=mgmt]/state/oper-status'}\n"
         }
       ]
     },
     {
       "test_name": "Subscribe SAMPLE to AAA State",
       "success": true,
+      "duration_sec": 8,
+      "results": [
+        {
+          "test_case": "testSubscribeSample",
+          "test_class": "CheckLeafsFromModel",
+          "test_module": "oc_config_validate.testcases",
+          "start_time_sec": 1755724191,
+          "duration_sec": 8,
+          "result": "PASS",
+          "log": ""
+        }
+      ]
+    },
+    {
+      "test_name": "Subscribe SAMPLE to Interfaces Counters",
+      "success": false,
       "duration_sec": 7,
       "results": [
         {
           "test_case": "testSubscribeSample",
-          "test_class": "CheckLeafs",
+          "test_class": "CheckLeafsFromModel",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576220,
+          "start_time_sec": 1755724199,
           "duration_sec": 7,
-          "result": "PASS",
-          "log": ""
+          "result": "FAIL",
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py\", line 136, in testSubscribeSample\n    self.subscribeSample()\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py\", line 70, in subscribeSample\n    self.assertEqual(\nAssertionError: 8 != 4 : 8 Updates for /interfaces/interface[name=mgmt]/state/oper-status, wanted 4\n"
         }
       ]
     },
@@ -127,9 +159,9 @@
       "results": [
         {
           "test_case": "testSubscribeSample",
-          "test_class": "CountUpdates",
+          "test_class": "CountUpdatePaths",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576227,
+          "start_time_sec": 1755724206,
           "duration_sec": 7,
           "result": "PASS",
           "log": ""
@@ -143,12 +175,12 @@
       "results": [
         {
           "test_case": "testSubscribeSample",
-          "test_class": "CheckLeafs",
+          "test_class": "CheckLeafsFromModel",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576234,
+          "start_time_sec": 1755724213,
           "duration_sec": 0,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py\", line 116, in testSubscribeSample\n    self.assertModelXpath(self.model, self.xpath)\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 422, in assertModelXpath\n    self.assertTrue(\nAssertionError: False is not true : xpath interfaces/interface[name=mgmt]/state/enabled does not point to a container in model system.openconfig_system: 'openconfig_system' object has no attribute 'interfaces'\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py\", line 132, in testSubscribeSample\n    self.assertModelXpath(self.model, self.xpath)\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testbase.py\", line 471, in assertModelXpath\n    self.assertTrue(\nAssertionError: False is not true : xpath interfaces/interface[name=mgmt]/state/enabled does not point to a container in model system.openconfig_system: 'openconfig_system' object has no attribute 'interfaces'\n"
         }
       ]
     },
@@ -159,17 +191,17 @@
       "results": [
         {
           "test_case": "testSubscribeSample",
-          "test_class": "CountUpdates",
+          "test_class": "CountUpdatePaths",
           "test_module": "oc_config_validate.testcases",
-          "start_time_sec": 1683576234,
+          "start_time_sec": 1755724213,
           "duration_sec": 5,
           "result": "FAIL",
-          "log": "\n Traceback (most recent call last):\n  File \"/home/itamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py\", line 93, in testSubscribeSample\n    self.assertEqual(\nAssertionError: 3 != 4 : Expected 4 Update paths, got: 3\n"
+          "log": "\n Traceback (most recent call last):\n  File \"/home/joseignaciotamayo/gnxi/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py\", line 106, in testSubscribeSample\n    self.assertEqual(\nAssertionError: 3 != 4 : Expected 4 Update paths, got: ['/interfaces/interface[name=FortyGigabitEthernet1/1/1]/state/oper-status', '/interfaces/interface[name=FortyGigabitEthernet1/1/2]/state/oper-status', '/interfaces/interface[name=mgmt]/state/oper-status']\n"
         }
       ]
     }
   ],
   "tests_pass": 5,
-  "tests_total": 10,
-  "tests_fail": 5
+  "tests_total": 12,
+  "tests_fail": 7
 }

--- a/oc_config_validate/demo/telemetry_tests.yaml
+++ b/oc_config_validate/demo/telemetry_tests.yaml
@@ -25,11 +25,20 @@ tests:
   
 - !TestCase
   name: "Subscribe ONCE to AAA State"
-  class_name: telemetry_once.CheckLeafs
+  class_name: telemetry_once.CheckLeafsFromModel
   args:
     xpaths:
-    - "system/aaa/authentication/state"
+    - "/system/aaa/authentication/state"
     model: system.openconfig_system
+
+- !TestCase
+  name: "Subscribe ONCE to Interfaces Counters"
+  class_name: telemetry_once.CheckLeafsFromModel
+  args:
+    xpaths:
+    - "interfaces/interface[name=mgmt]/state"
+    model: interfaces.openconfig_interfaces
+    check_missing_model_paths: true
 
 - !TestCase
   name: "Subscribe ONCE to all Interfaces oper-status"
@@ -55,31 +64,41 @@ tests:
   class_name: telemetry_once.CountUpdatesCheckType
   args:
     xpaths: 
-    - "interfaces/interface[name=mgmt]/state/enabled"
-    values_type: string_val
+    - "interfaces/interface[name=mgmt]/state/oper-status"
+    values_type: bool_val
     updates_count: 1
 
 - !TestCase
   name: "Bad - Expected 4 Updates"
-  class_name: telemetry_once.CountUpdatesCheckType
+  class_name: telemetry_once.CountUpdatePaths
   args:
     xpaths: 
     - "interfaces/interface[name=*]/state/oper-status"
-    values_type: string_val
-    updates_count: 4
+    update_paths_count: 4
   
 - !TestCase
   name: "Subscribe SAMPLE to AAA State"
-  class_name: telemetry_sample.CheckLeafs
+  class_name: telemetry_sample.CheckLeafsFromModel
   args:
-    xpath: "system/aaa/authentication/state"
+    xpath: "/system/aaa/authentication/state"
     model: system.openconfig_system
+    check_missing_model_paths: true
+    sample_interval: 2
+    sample_timeout: 7
+
+- !TestCase
+  name: "Subscribe SAMPLE to Interfaces Counters"
+  class_name: telemetry_sample.CheckLeafsFromModel
+  args:
+    xpath: "interfaces/interface[name=mgmt]/state"
+    model: interfaces.openconfig_interfaces
+    check_missing_model_paths: true
     sample_interval: 2
     sample_timeout: 7
 
 - !TestCase
   name: "Subscribe SAMPLE to all Interfaces oper-status"
-  class_name: telemetry_sample.CountUpdates
+  class_name: telemetry_sample.CountUpdatePaths
   args:
     xpath: "interfaces/interface[name=*]/state/oper-status"
     update_paths_count: 3
@@ -88,7 +107,7 @@ tests:
 
 - !TestCase
   name: "Bad - Wrong model"
-  class_name: telemetry_sample.CheckLeafs
+  class_name: telemetry_sample.CheckLeafsFromModel
   args:
     xpath: "interfaces/interface[name=mgmt]/state/enabled"
     model: system.openconfig_system
@@ -97,7 +116,7 @@ tests:
     
 - !TestCase
   name: "Bad - Expected 4 Update Paths"
-  class_name: telemetry_sample.CountUpdates
+  class_name: telemetry_sample.CountUpdatePaths
   args:
     xpath: "interfaces/interface[name=*]/state/oper-status"
     sample_interval: 2

--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -352,6 +352,19 @@ Args:
   *  *max_timestamp_drift_secs*: Maximum drift for the timestamp(s).
 
 
+####  `telemetry_once.CountUpdatePaths`
+
+In addition to the default checks of the module, this test checks the
+Subscription to the xpaths produces Updates for a determined number of distinct paths.
+
+> If multiple Notifications and/or Updates are received for the same path, it is counted regardless as only 1 distinct path.
+
+Args:
+ *  **xpaths**: List of gNMI paths to subscribe to. Paths can contain
+     wildcard '*', as `/interaces/interface[name=*]/state/oper-status` or `/interaces/interface[name=eth0]/*/enabled`.
+ * **update_paths_count**: Number of expected distinct Update paths.
+
+
 ####  `telemetry_once.CountUpdatesCheckType`
 
 In addition to the default checks of the module, this test checks that the

--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -342,7 +342,7 @@ Optionally, every Update messages can have its timestamp value checked
   against the local time when the Subscription message was sent. The absolute
   time drift is compared against a max value in secs.
 
-Optionally, the number of expected Notifications (equals to the amount of)
+Optionally, the number of expected Notifications (equals to the amount of
   timestamps) is checked.
 
 > If the arguments are not present in the test, the check is not performed.
@@ -363,18 +363,17 @@ All Update values are expected to be of the same Type, as 'string_val',
   'int_val', etc.
 
 Args:
- *  **xpaths**: List of gNMI paths to subscribe to. Paths can contain
-     wildcard '*'.
+ *  **xpaths**: List of gNMI paths to subscribe to. Paths can contain wildcard '*'.
  *  **updates_count**: Number of expected Update messages.
  *  **values_type**: Python type of the values of the Updates.
 
 
-####  `telemetry_once.CheckLeafs`
+####  `telemetry_once.CheckLeafsFromModel`
 
 In addition to the default checks of the module, this test checks that the
 subscription to containers updates all leafs.
 
-This test subscribes only xpaths of containers. It renders the
+**This test subscribes only xpaths of containers**. It renders the
 corresponding OC model and lists all paths to the downstream Leafs. The
 Update paths received in the Subscription reply are checked against the
 Leafs of the Model (Update paths must match an OC Model Leaf).
@@ -387,7 +386,7 @@ have all Leaf paths that the OC mode has.
 
 Args:
  *  **xpaths**: List of gNMI paths to subscribe to.
-     Paths can contain wildcards only in keys '*'.
+     Paths can contain wildcard '*' only in keys.
  *  **model**: Python binding class to check the reply against.
  *  *check_missing_model_paths*: If True, it asserts that all OC Model Leaf
      paths are in the received Updates. Defaults to False.
@@ -396,7 +395,7 @@ Args:
 
 Uses gNMI Subscribe messages, of type STREAM, mode SAMPLE.
 
-This test subscribes to a single gNMI xpath, request sampled streaming
+This test subscribes to a **single gNMI xpath**, request sampled streaming
 telemetry and keep accumulating responses up to a timeout.
 After the timeout, it checks that all returned paths have the same number of
 updates, and that the time interval between updates is the requested value
@@ -409,10 +408,19 @@ interval for 65 secs. The Target replies with Updates for several paths
 65 secs, the test checks that all paths have 5 updates, and for each path,
 that the timestamp difference of updates is 15 secs.
 
+The following Subscription Updates will pass this test:
+
  Update path | Time
  ----------- | ----
  `/<root>/<container>/<leaf1>` | Update[t0] >> Update[t15] >> Update[t30] >> ...
  `/<root>/<container>/<leaf2>` | Update[t0] >> Update[t18] >> Update[t25] >> ...
+
+The following Subscription Updates will FAIL this test:
+
+Update path | Time
+ ----------- | ----
+`/<root>/<container>/<leaf1>` | Update[t0] |             | Update[t30] |
+`/<root>/<container>/<leaf2>` |            | Update[t15] | Update[t29] |
 
 > These checks do not validate the values returned on the updates.
 > Use telemetry_once.* for that.
@@ -423,53 +431,62 @@ Args:
  *  *max_timestamp_drift_secs*: Maximum drift for the timestamp(s) in the
     reply. Defaults to 1 sec.
 
-####  `telemetry_sample.CountUpdates`
+####  `telemetry_sample.CountUpdatePaths`
 
 In addition to the default checks of the module, this test checks the
 Subscription to the xpath produces Updates for a determined number of paths.
 
 E.g:
 Suppose the test is subscribing to an xpath `/<root>/<container>`, with 15 secs
-interval for 65 secs, expecting 3 Update paths. After collecting subscription
+interval for 65 secs, **expecting 3 Update paths**. After collecting subscription
 responses for 65 secs, the test checks that there are Updates for 3 xpaths.
 
-Update path | t0 | t15 | t30 | t45 | t60
------------ | -- | --- | --- | --- | ---
-`/<root>/<container>/<leaf1>` | value | value | value | value | value
-`/<root>/<container>/<leaf2>` |       | value | value |       |
-`/<root>/<container>/<leaf3>` | value |       | value |       | value
+The following Subscription Updates will FAIL this test:
+
+Update path | Time
+ ----------- | ----
+`/<root>/<container>/<leaf1>` | Update[t0] | Update[t15] | Update[t30] |
+`/<root>/<container>/<leaf2>` | Update[t0] | Update[t15] | Update[t29] |
 
 Args:
  *  **xpath**: gNMI path to subscribe to. Path can contain wildcards '*'.
  * **update_paths_count**: Number of expected distinct Update paths.
 
-####  `telemetry_sample.CheckLeafs`
+####  `telemetry_sample.CheckLeafsFromModel`
 
 In addition to the default checks of the module, this test checks that the
 subscription to a container updates all leafs under it.
 
+**This test subscribes only xpaths of containers**. 
 It renders the corresponding OC model and lists all paths to the downstream
 Leafs. The Update paths received in the Subscription replies are checked
 against the Leafs of the model (all Update paths must match an OC model Leaf).
 
- E.g:
- Suppose the test is subscribing to an xpath `/<root>/<container>/state`, with
- 15 secs interval for 65 secs. After collecting subscription responses for 65
- secs, the test checks that all Update paths are valid in the given OC model,
- and that there are updates for all paths.
+Optionally, use `check_missing_model_paths` to assert that all OC model paths
+are present in the Updates. Usually, the Subscription replies might not
+have all Leaf paths that the OC mode has.
 
- Update path | t0 | t15 | t30 | t45 | t60
- ----------- | -- | --- | --- | --- | ---
- `/<root>/<container>/state/<leaf1>` | value | value | value | value | value
- `/<root>/<container>/state/<leaf2>` |       | value | value |       |
- `/<root>/<container>/state/<leaf3>` | value |       | value |       | value
+E.g:
+Suppose the test is subscribing to an xpath `/<root>/<container>`, with
+15 secs interval for 65 secs. After collecting subscription responses for 65
+secs, the test checks that all Update paths are valid in the given OC model,
+and that there are updates for all paths.
+
+The following Subscription Updates will FAIL this test:
+
+Update path | Time
+ ----------- | ----
+`/<root>/<container>/<leaf1>` | Update[t0] | Update[t15] | Update[t30] |
+`/<root>/<container>/<not_a_leaf_in_model>` | Update[t0] | Update[t15] | Update[t29] |
 
 > This check does NOT check the type of the values returned.
 
 Args:
  *  **xpath**: gNMI path to subscribe to.
-    Can contain wildcards only in keys '*'.
+    Can contain wildcard '*' only in keys.
  *  **model**: Python binding class to check the replies against.
+ *  *check_missing_model_paths*: If True, it asserts that all OC Model Leaf
+     paths are in the received Updates. Defaults to False.
 
 ### Module telemetry_onchange
 

--- a/oc_config_validate/docs/testclasses.md
+++ b/oc_config_validate/docs/testclasses.md
@@ -362,6 +362,8 @@ the Subscription.
 All Update values are expected to be of the same Type, as 'string_val',
   'int_val', etc.
 
+> This Testclass might not be useful for testing paths to Containers, as it has several Leafs of likely different value types.
+
 Args:
  *  **xpaths**: List of gNMI paths to subscribe to. Paths can contain wildcard '*'.
  *  **updates_count**: Number of expected Update messages.

--- a/oc_config_validate/lint.sh
+++ b/oc_config_validate/lint.sh
@@ -11,8 +11,8 @@ done
 echo "---Linting YAML files in ${BASEDIR}/tests"
 yamllint -d relaxed "${BASEDIR}/tests/"
 
-echo "---Formatting and Linting Python files in ${BASEDIR}/oc_config_validate"
-python3 -m autopep8 -i ${BASEDIR}/oc_config_validate/*.py ${BASEDIR}/oc_config_validate/testcases/*.py ${BASEDIR}/py_tests/*.py
-python3 -m isort ${BASEDIR}/oc_config_validate/*.py ${BASEDIR}/oc_config_validate/testcases/*.py ${BASEDIR}/py_tests/*.py
-python3 -m pylama -l pycodestyle,pyflakes ${BASEDIR}/oc_config_validate/*.py ${BASEDIR}/oc_config_validate/testcases/*.py ${BASEDIR}/py_tests/*.py && \
-    python3 -m pytype -k -x="${BASEDIR}/oc_config_validate/models" -x="${BASEDIR}/oc_config_validate/gnmi"  ${BASEDIR}/oc_config_validate/
+echo "---Formatting and Linting Python files in ${BASEDIR}"
+python3 -m autopep8 -i ${BASEDIR}/oc_config_validate/*.py ${BASEDIR}/oc_config_validate/testcases/*.py ${BASEDIR}/py_tests/*.py ${BASEDIR}/py_tests/testcases/*.py
+python3 -m isort ${BASEDIR}/oc_config_validate/*.py ${BASEDIR}/oc_config_validate/testcases/*.py ${BASEDIR}/py_tests/*.py ${BASEDIR}/py_tests/testcases/*.py
+python3 -m pylama -l pycodestyle,pyflakes ${BASEDIR}/oc_config_validate/*.py ${BASEDIR}/oc_config_validate/testcases/*.py ${BASEDIR}/py_tests/*.py  ${BASEDIR}/py_tests/testcases/*.py && \
+  python3 -m pytype -k -x="${BASEDIR}/oc_config_validate/models" -x="${BASEDIR}/oc_config_validate/gnmi"  ${BASEDIR}/oc_config_validate/

--- a/oc_config_validate/oc_config_validate/schema.py
+++ b/oc_config_validate/oc_config_validate/schema.py
@@ -243,7 +243,7 @@ def ocLeafsPaths(model: str, xpath: str) -> List[str]:
         if isinstance(val, dict):
             paths.extend(ocLeafsPaths(model, xpath + "/" + leaf))
         else:
-            paths.append(xpath + "/" + leaf)
+            paths.append(pathToString(parsePath(xpath + "/" + leaf)))
     return paths
 
 

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
@@ -142,21 +142,16 @@ class CheckLeafsFromModel(SubsOnceTestCase):
         for n in self.responses:
             got_updates.extend(n.update)
 
-        self.assertGreater(
-            len(got_updates), 0,
-            "There are no Updates as reply to the Subscription")
-
         got_paths = set()
         for u in got_updates:
             got_path = schema.pathToString(u.path)
             got_paths.add(got_path)
             self.assertTrue(
                 schema.isPathInRequestedPaths(got_path, want_paths),
-                f"Unexpected update path {got_path} for subscription")
+                f"Update path {got_path} NOT in OC Model {self.model}")
 
         if self.check_missing_model_paths:
             for want_path in want_paths:
                 self.assertIn(
-                    want_path, got_paths,
-                    f"Missing update path {want_path} for OC model"
-                    f" {self.model}, got {got_paths}")
+                    want_path, list(got_paths),
+                    f"Missing update path for OC model {self.model}")

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
@@ -29,6 +29,13 @@ class SubsOnceTestCase(testbase.TestCase):
         self.assertTrue(bool(self.responses),
                         "No gNMI Subscribe response")
 
+        for n in self.responses:
+            for u in n.update:
+                got_path = schema.pathToString(u.path)
+                self.assertTrue(
+                    schema.isPathInRequestedPaths(got_path, self.xpaths),
+                    f"Unexpected update path {got_path} for subscription to {self.xpaths}")
+
         if self.max_delay_secs:
             for n in self.responses:
                 timestamp_diff = (n.timestamp // 1000000000) - self.now
@@ -57,7 +64,7 @@ class CountUpdatesCheckType(SubsOnceTestCase):
     values_type = None
     updates_count = None
 
-    def test100(self):
+    def testSubscribeOnce(self):
         """"""
         self.assertArgs(["xpaths", "values_type", "updates_count"])
 
@@ -67,10 +74,6 @@ class CountUpdatesCheckType(SubsOnceTestCase):
         for n in self.responses:
             updates += len(n.update)
             for u in n.update:
-                got_path = schema.pathToString(u.path)
-                self.assertTrue(
-                    schema.isPathInRequestedPaths(got_path, self.xpaths),
-                    f"Unexpected update path {got_path} for subscription")
                 self.assertTrue(
                     u.val.HasField(self.values_type),
                     f"Value of Update {schema.pathToString(u.path)} "
@@ -80,8 +83,37 @@ class CountUpdatesCheckType(SubsOnceTestCase):
             updates, self.updates_count,
             f"Expected {self.updates_count} Updates, got: {updates}")
 
+class CountUpdatePaths(SubsOnceTestCase):
+    """Subscribes ONCE and checks the returned update paths.
 
-class CheckLeafs(SubsOnceTestCase):
+    This tests that a Subscription reports all Update paths.
+
+    Args:
+        xpaths: List of gNMI paths to subscribe to. Can contain wildcards.
+        paths_count: Number of expected disctinct Update paths.
+    """
+    update_paths_count = None
+
+    def testSubscribeOnce(self):
+        """"""
+        self.assertArgs(["xpaths", "update_paths_count"])
+        self.subscribeOnce()
+
+        self.update_paths = set()
+
+        for n in self.responses:
+            for u in n.update:
+                self.update_paths.add(schema.pathToString(u.path))
+        
+        self.assertEqual(
+            len(self.update_paths), self.update_paths_count,
+            f"Expected {self.update_paths_count} Update paths, "
+            f"got: {self.update_paths}")
+                
+        
+        
+        
+class CheckLeafsFromModel(SubsOnceTestCase):
     """Subscribes ONCE and checks the updates againts the OC model.
 
     All arguments are read from the Test YAML description.
@@ -96,7 +128,7 @@ class CheckLeafs(SubsOnceTestCase):
     model = None
     check_missing_model_paths = False
 
-    def test100(self):
+    def testSubscribeOnce(self):
         """"""
         self.assertArgs(["xpaths", "model"])
 
@@ -115,10 +147,10 @@ class CheckLeafs(SubsOnceTestCase):
             len(got_updates), 0,
             "There are no Updates as reply to the Subscription")
 
-        got_paths = []
+        got_paths = set()
         for u in got_updates:
             got_path = schema.pathToString(u.path)
-            got_paths.append(got_path)
+            got_paths.add(got_path)
             self.assertTrue(
                 schema.isPathInRequestedPaths(got_path, want_paths),
                 f"Unexpected update path {got_path} for subscription")

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_once.py
@@ -83,6 +83,7 @@ class CountUpdatesCheckType(SubsOnceTestCase):
             updates, self.updates_count,
             f"Expected {self.updates_count} Updates, got: {updates}")
 
+
 class CountUpdatePaths(SubsOnceTestCase):
     """Subscribes ONCE and checks the returned update paths.
 
@@ -104,15 +105,13 @@ class CountUpdatePaths(SubsOnceTestCase):
         for n in self.responses:
             for u in n.update:
                 self.update_paths.add(schema.pathToString(u.path))
-        
+
         self.assertEqual(
             len(self.update_paths), self.update_paths_count,
             f"Expected {self.update_paths_count} Update paths, "
             f"got: {self.update_paths}")
-                
-        
-        
-        
+
+
 class CheckLeafsFromModel(SubsOnceTestCase):
     """Subscribes ONCE and checks the updates againts the OC model.
 

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py
@@ -135,20 +135,15 @@ class CheckLeafsFromModel(SubsSampleTestCase):
 
         self.subscribeSample()
 
-        if self.responses:
-            got_paths = self.responses.keys()
+        got_paths = list(self.responses.keys())
 
-        self.assertGreater(len(got_paths), 0,
-                           "There are no Update replies to the Subscription")
-
-        for p in got_paths:
+        for got_path in got_paths:
             self.assertTrue(
-                schema.isPathInRequestedPaths(p, want_paths),
-                f"Unexpected update path {p} for subscription")
+                schema.isPathInRequestedPaths(got_path, want_paths),
+                f"Update path {got_path} NOT in OC Model {self.model}")
 
         if self.check_missing_model_paths:
             for want_path in want_paths:
                 self.assertIn(
                     want_path, got_paths,
-                    f"Missing update path {want_path} for OC model"
-                    f" {self.model}, got {got_paths}")
+                    f"Missing update path for OC model {self.model}")

--- a/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py
+++ b/oc_config_validate/oc_config_validate/testcases/telemetry_sample.py
@@ -51,7 +51,7 @@ class SubsSampleTestCase(testbase.TestCase):
             self.xpath,
             self.sample_interval * SECS_TO_NSEC,
             timeout=self.sample_timeout)
-        self.assertIsNotNone(notifications, "No gNMI Subscribe response")
+        self.assertTrue(bool(notifications), "No gNMI Subscribe response")
 
         self.responses = collections.defaultdict(list)
         for n in notifications:
@@ -63,10 +63,13 @@ class SubsSampleTestCase(testbase.TestCase):
         want = (self.sample_timeout // self.sample_interval) + 1
         if self.responses:
             for path, updates in self.responses.items():
+                self.assertTrue(
+                    schema.isPathInRequestedPaths(path, [self.xpath]),
+                    f"Unexpected update path {path} for subscription to {self.xpath}")
                 got = len(updates)
                 self.assertEqual(
                     got, want,
-                    f"{got} Updates for path {path}, wanted {want}")
+                    f"{got} Updates for {path}, wanted {want}")
                 if len(updates) > 1:
                     timestamp_0, _ = updates[0]
                     timeline = []
@@ -78,19 +81,20 @@ class SubsSampleTestCase(testbase.TestCase):
                                 timestamp_diff,
                                 self.sample_interval * SECS_TO_NSEC,
                                 self.max_timestamp_drift_secs * SECS_TO_NSEC),
-                            f"Subscribe updates for '{path}' received out of sample interval {self.sample_interval} secs, "
+                            f"Subscribe updates for '{path}' received out of "
+                            f"sample interval {self.sample_interval} secs, "
                             f"received updates intervals: {timeline}")
                         timestamp_0 = timestamp_1
 
 
-class CountUpdates(SubsSampleTestCase):
+class CountUpdatePaths(SubsSampleTestCase):
     """Subscribes SAMPLE and checks the returned update paths.
 
     This tests that a Subscription consistenly reports all Update paths.
 
     Args:
         xpath: gNMI paths to subscribe to. Can contain wildcards.
-        updates_count: Number of expected disctinct Update paths, per reply.
+        update_paths_count: Number of expected disctinct Update paths.
     """
     update_paths_count = None
 
@@ -102,10 +106,10 @@ class CountUpdates(SubsSampleTestCase):
         self.assertEqual(
             got_paths, self.update_paths_count,
             f"Expected {self.update_paths_count} Update paths, "
-            f"got: {got_paths}")
+            f"got: {list(self.responses.keys())}")
 
 
-class CheckLeafs(SubsSampleTestCase):
+class CheckLeafsFromModel(SubsSampleTestCase):
     """Subscribes SAMPLE and checks the updates againts the state OC model.
 
     Tests that a Sample Subscription consistenly reports all Update paths, and
@@ -115,22 +119,36 @@ class CheckLeafs(SubsSampleTestCase):
         xpath: gNMI paths to subscribe to. Can contain wildcards only on the
           keys.
         model: Python binding class to check the replies against.
+        check_missing_model_paths: If True, missing OC Model leaf paths in the
+                                   Updates replies are checked.
     """
     model = None
+    check_missing_model_paths = False
 
     def testSubscribeSample(self):
         """"""
         self.assertArgs(["model", "xpath"])
 
         self.assertModelXpath(self.model, self.xpath)
+        want_paths = schema.ocLeafsPaths(self.model, self.xpath)
+        got_paths = []
 
         self.subscribeSample()
 
-        got_paths = len(self.responses)
-        self.assertGreater(got_paths, 0,
-                           "There are no Update replies to the Subscription")
         if self.responses:
-            for path, _ in self.responses.items():
-                self.assertTrue(
-                    schema.isPathInRequestedPaths(path, [self.xpath]),
-                    f"Unexpected update path {path} for subscription")
+            got_paths = self.responses.keys()
+
+        self.assertGreater(len(got_paths), 0,
+                           "There are no Update replies to the Subscription")
+
+        for p in got_paths:
+            self.assertTrue(
+                schema.isPathInRequestedPaths(p, want_paths),
+                f"Unexpected update path {p} for subscription")
+
+        if self.check_missing_model_paths:
+            for want_path in want_paths:
+                self.assertIn(
+                    want_path, got_paths,
+                    f"Missing update path {want_path} for OC model"
+                    f" {self.model}, got {got_paths}")

--- a/oc_config_validate/py_tests/.gitignore
+++ b/oc_config_validate/py_tests/.gitignore
@@ -1,1 +1,1 @@
-/__pycache__/
+**/__pycache__/

--- a/oc_config_validate/py_tests/test_runner.py
+++ b/oc_config_validate/py_tests/test_runner.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import unittest
+from unittest import mock
 
 from oc_config_validate import context, runner, target, testcases
 
@@ -44,7 +45,8 @@ class TestGetTestSuites(unittest.TestCase):
             self.assertEqual(getattr(t, "arg1", None), "foo")
             self.assertEqual(getattr(t, "arg2", None), "bar")
 
-    def test_getTestSuites_error(self):
+    @mock.patch('logging.error')    # Avoid logging errors in the test output
+    def test_getTestSuites_error(self, mock_error_log):
         tgt = target.TestTarget(context.Target())
         tests = [
             context.TestCase("notAClass",

--- a/oc_config_validate/py_tests/test_schema.py
+++ b/oc_config_validate/py_tests/test_schema.py
@@ -124,18 +124,23 @@ class TestParsePaths(unittest.TestCase):
     @parameterized.expand([
         ("_full_path",
          "/protocols/protocol[identifier=BGP][name=bgp]/bgp/global",
-         True),
-        ("_root_path", "/", True),
-        ("_basic_path", "/system", True),
+         True,
+         "/protocols/protocol[identifier=BGP][name=bgp]/bgp/global"),
+        ("_root_path", "/", True, "/"),
+        ("_basic_path", "/system", True, "/system"),
+        ("_unrooted_path", "system/state", True, "/system/state"),
+        ("_appended_path", "/system/state/", True, "/system/state"),
         ("_bad_index",
          "/network-instances/network-instance[default]",
-         False)
+         False,
+         "")
     ])
-    def test_pathStrings(self, name, path_str, is_ok):
+    def test_pathStrings(self, name, path_str, is_ok, parsed_path_string):
         self.assertEqual(schema.isPathOK(path_str), is_ok, name)
         if is_ok:
             got_obj = schema.parsePath(path_str)
-            self.assertEqual(path_str, schema.pathToString(got_obj), name)
+            self.assertEqual(parsed_path_string,
+                             schema.pathToString(got_obj), name)
 
 
 class TestisPathInRequestedPathsRequestedPaths(unittest.TestCase):

--- a/oc_config_validate/py_tests/testcases/test_telemetry_once.py
+++ b/oc_config_validate/py_tests/testcases/test_telemetry_once.py
@@ -14,10 +14,10 @@ limitations under the License.
 
 """
 
+import re
 import time
 import unittest
 from unittest import mock
-import re
 
 from parameterized import parameterized
 
@@ -28,6 +28,7 @@ from oc_config_validate.testcases import telemetry_once
 unittest.TestLoader.testMethodPrefix = 'check'
 mock.patch.TEST_PREFIX = 'check'
 
+
 @mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
 class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
     """Test for SubsOnceTestCase class."""
@@ -37,7 +38,7 @@ class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
 
     def check_bad_path(self, mock_gNMISubsOnce):
         """Test that subscribeOnce raises an error for bad path."""
-        self.xpaths = ['/network-instances/network-instance[default]']
+        self.xpaths.append('/network-instances/network-instance[default]')
         with self.assertRaises(AssertionError):
             self.subscribeOnce()
         mock_gNMISubsOnce.assert_not_called()
@@ -65,6 +66,46 @@ class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
                 timestamp=(int(time.time()) + 10) * 1000000000)  # 10 second later
         ] * got
         with self.assertRaisesRegex(AssertionError, f"Expected {want} notifications, got {got}"):
+            self.subscribeOnce()
+
+    def check_bad_update_path(self, mock_gNMISubsOnce):
+        """Test subscribeOnce when the path of an update is not as subscribed."""
+
+        self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
+        mock_gNMISubsOnce.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=(int(time.time()) + 10) *
+                1000000000,  # 10 second later
+                update=[
+                    gnmi_pb2.Update(
+                        path=gnmi_pb2.Path(elem=[
+                            gnmi_pb2.PathElem(name='interfaces'),
+                            gnmi_pb2.PathElem(
+                                name='interface', key={'name': 'eth0'}),
+                            gnmi_pb2.PathElem(name='state'),
+                            gnmi_pb2.PathElem(name='oper-status')
+                        ]),
+                        val=gnmi_pb2.TypedValue(string_val='UP')
+                    ),
+                    gnmi_pb2.Update(
+                        path=gnmi_pb2.Path(
+                            elem=[
+                                gnmi_pb2.PathElem(name='system'),
+                                gnmi_pb2.PathElem(name='state'),
+                                gnmi_pb2.PathElem(name='hostname')],
+
+                        ),
+                        val=gnmi_pb2.TypedValue(string_val='localhost')
+
+                    )
+                ])
+
+        ]
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                "False is not true : "
+                "Unexpected update path /system/state/hostname for subscription"):
             self.subscribeOnce()
 
     def check_ok_nothing_checked(self, mock_gNMISubsOnce):
@@ -112,7 +153,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
             update=[
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth0'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -122,7 +163,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
                 ),
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth1'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -132,7 +173,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
                 ),
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'mgmt'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -147,7 +188,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
             update=[
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth0'}),
                         gnmi_pb2.PathElem(name='config'),
@@ -157,7 +198,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
                 ),
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth0'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -173,7 +214,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
             update=[
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth0'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -183,7 +224,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
                 ),
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth0'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -193,7 +234,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
                 ),
                 gnmi_pb2.Update(
                     path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(name='interfaces'),
                         gnmi_pb2.PathElem(
                             name='interface', key={'name': 'eth0'}),
                         gnmi_pb2.PathElem(name='state'),
@@ -206,23 +247,21 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
 
     def check_bad_args(self, mock_gNMISubsOnce):
         """Test that CountUpdatesCheckType raises an error for missing arguments."""
-        self.xpaths = []
-
         with self.assertRaises(AssertionError):
-            self.test100()
+            self.testSubscribeOnce()
 
         self.xpaths = ['/valid/path']
         with self.assertRaises(AssertionError):
-            self.test100()
+            self.testSubscribeOnce()
 
         self.values_type = 'string_val'
         with self.assertRaises(AssertionError):
-            self.test100()
-        
+            self.testSubscribeOnce()
+
         self.values_type = None
         self.updates_count = 1
         with self.assertRaises(AssertionError):
-            self.test100()
+            self.testSubscribeOnce()
 
         mock_gNMISubsOnce.assert_not_called()
 
@@ -235,65 +274,39 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
             self.response_hostname
         ]
         with self.assertRaisesRegex(AssertionError, "1 != 3 : Expected 3 Updates, got: 1"):
-            self.test100()
+            self.testSubscribeOnce()
 
         self.updates_count = 1
-        self.xpaths = ['/interaces/interface[name=*]/state/oper-status']
+        self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
         mock_gNMISubsOnce.return_value = [
             self.response_interface_status
         ]
         with self.assertRaisesRegex(AssertionError, "3 != 1 : Expected 1 Updates, got: 3"):
-            self.test100()
+            self.testSubscribeOnce()
 
     def check_bad_type(self, mock_gNMISubsOnce):
         """Test CountUpdatesCheckType when the value type is not as expected."""
 
         self.values_type = 'string_val'
         self.updates_count = 3
-        self.xpaths = ['/interaces/interface[name=*]/state/oper-status']
+        self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
         self.response_interface_status.update[1].val.ClearField('string_val')
         self.response_interface_status.update[1].val.int_val = 1
-        
+
         mock_gNMISubsOnce.return_value = [
             self.response_interface_status
         ]
         with self.assertRaisesRegex(
                 AssertionError,
                 re.compile(r"False is not true : "
-                           r"Value of Update /interaces/interface\[name=eth1\]/state/oper-status "
+                           r"Value of Update /interfaces/interface\[name=eth1\]/state/oper-status "
                            r"is not of type string_val: .*")):
-            self.test100()
-
-    def check_bad_update_path(self, mock_gNMISubsOnce):
-        """Test CountUpdatesCheckType when the path of an update is not as expected."""
-
-        self.xpaths = ['/interaces/interface[name=*]/state/oper-status']
-        self.values_type = 'string_val'
-        self.updates_count = 4
-        self.response_interface_status.update.append(
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path( 
-                    elem=[
-                gnmi_pb2.PathElem(name='system'),
-                gnmi_pb2.PathElem(name='state'),
-                gnmi_pb2.PathElem(name='hostname')],
-
-                ),
-                val=gnmi_pb2.TypedValue(string_val='localhost')
-            
-            ))
-        mock_gNMISubsOnce.return_value = [
-            self.response_interface_status
-        ]
-        with self.assertRaisesRegex(
-                AssertionError,
-                "False is not true : Unexpected update path /system/state/hostname for subscription"):
-            self.test100()
+            self.testSubscribeOnce()
 
     def check_container(self, mock_gNMISubsOnce):
         """Test CountUpdatesCheckType when the path of an update is a container."""
 
-        self.xpaths = ['/interaces/interface[name=eth0]/state']
+        self.xpaths = ['/interfaces/interface[name=eth0]/state']
         self.values_type = 'string_val'
         self.updates_count = 3
         mock_gNMISubsOnce.return_value = [
@@ -302,30 +315,197 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
         with self.assertRaisesRegex(
                 AssertionError,
                 re.compile(r"False is not true : "
-                           r"Value of Update /interaces/interface\[name=eth0\]/state/mtu "
+                           r"Value of Update /interfaces/interface\[name=eth0\]/state/mtu "
                            r"is not of type string_val: .*")):
-            self.test100()
+            self.testSubscribeOnce()
 
-    def check_ok(self, mock_gNMISubsOnce):
+    def check_wildcards_ok(self, mock_gNMISubsOnce):
         """Test that CountUpdatesCheckType works as expected."""
         self.xpaths = [
             '/system/state/hostname',
-            '/interaces/interface[name=*]/state/oper-status']
+            '/interfaces/interface[name=*]/state/oper-status']
         self.updates_count = 4
         self.values_type = 'string_val'
         mock_gNMISubsOnce.return_value = [
             self.response_interface_status,
             self.response_hostname
         ]
-        self.test100()
+        self.testSubscribeOnce()
 
-        self.xpaths = ['/interaces/interface[name=eth0]/*/enabled']
+        self.xpaths = ['/interfaces/interface[name=eth0]/*/enabled']
         self.updates_count = 2
         self.values_type = 'bool_val'
         mock_gNMISubsOnce.return_value = [
             self.response_interface_eth0_enabled
         ]
-        self.test100()
+        self.testSubscribeOnce()
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
+class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
+    """Test for CountUpdatePaths class."""
+
+    def setUp(self):
+
+        self.response_hostname = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='system'),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='hostname')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='localhost')
+                )
+            ]
+        )
+
+        self.response_interface_status = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='UP')
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth1'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='DOWN')
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'mgmt'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='UP')
+                )
+            ]
+        )
+        self.response_interface_eth0_enabled = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='config'),
+                        gnmi_pb2.PathElem(name='enabled')
+                    ]),
+                    val=gnmi_pb2.TypedValue(bool_val=True)
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='enabled')
+                    ]),
+                    val=gnmi_pb2.TypedValue(bool_val=False)
+                )
+            ]
+        )
+
+        self.response_interface_eth0_state = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='UP')
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='mtu')
+                    ]),
+                    val=gnmi_pb2.TypedValue(int_val=1500)
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interfaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='enabled')
+                    ]),
+                    val=gnmi_pb2.TypedValue(bool_val=True)
+                )
+            ]
+        )
+
+    def check_bad_args(self, mock_gNMISubsOnce):
+        """Test that CountUpdatePaths raises an error for missing argument."""
+        with self.assertRaises(AssertionError):
+            self.testSubscribeOnce()
+
+        self.xpaths = ['/valid/path']
+        with self.assertRaises(AssertionError):
+            self.testSubscribeOnce()
+
+        self.update_paths_count = 3
+        self.xpaths = None
+        with self.assertRaises(AssertionError):
+            self.testSubscribeOnce()
+
+        mock_gNMISubsOnce.assert_not_called()
+
+    def check_diff_count_updates(self, mock_gNMISubsOnce):
+        """Test CountUpdatePaths when the updates are not as expected."""
+        self.update_paths_count = 4
+        self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_status
+        ]
+        with self.assertRaisesRegex(
+            AssertionError, 
+            re.compile(
+            r"3 != 4 : Expected 4 Update paths, got: .*")            ):
+            self.testSubscribeOnce()
+
+        self.update_paths_count = 1
+        self.xpaths = ['/system/state']
+        mock_gNMISubsOnce.return_value = [
+            self.response_hostname,
+            self.response_hostname,
+        ]
+        self.testSubscribeOnce()
+
+    def check_wildcards_ok(self, mock_gNMISubsOnce):
+        """Test that CountUpdatesCheckType works as expected."""
+        self.xpaths = [
+            '/interfaces/interface[name=eth0]/*/enabled',
+            '/interfaces/interface[name=*]/state/oper-status']
+        self.update_paths_count = 5
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_status,
+            self.response_interface_eth0_enabled,
+            self.response_interface_status,
+        ]
+        self.testSubscribeOnce()
 
 
 if __name__ == '__main__':

--- a/oc_config_validate/py_tests/testcases/test_telemetry_once.py
+++ b/oc_config_validate/py_tests/testcases/test_telemetry_once.py
@@ -14,6 +14,7 @@ limitations under the License.
 
 """
 
+import copy
 import re
 import time
 import unittest
@@ -27,6 +28,118 @@ from oc_config_validate.testcases import telemetry_once
 # Use 'check' instead of 'test', not to mix with test methods in oc_config_validate.testcases
 unittest.TestLoader.testMethodPrefix = 'check'
 mock.patch.TEST_PREFIX = 'check'
+
+response_hostname = gnmi_pb2.Notification(
+    timestamp=(int(time.time())) * 1000000000,
+    update=[
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='system'),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='hostname')
+            ]),
+            val=gnmi_pb2.TypedValue(string_val='localhost')
+        )
+    ]
+)
+
+response_interface_eth0_enabled = gnmi_pb2.Notification(
+    timestamp=(int(time.time())) * 1000000000,
+    update=[
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth0'}),
+                gnmi_pb2.PathElem(name='config'),
+                gnmi_pb2.PathElem(name='enabled')
+            ]),
+            val=gnmi_pb2.TypedValue(bool_val=True)
+        ),
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth0'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='enabled')
+            ]),
+            val=gnmi_pb2.TypedValue(bool_val=False)
+        )
+    ]
+)
+
+response_interface_eth0_state = gnmi_pb2.Notification(
+    timestamp=(int(time.time())) * 1000000000,
+    update=[
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth0'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='oper-status')
+            ]),
+            val=gnmi_pb2.TypedValue(string_val='UP')
+        ),
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth0'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='mtu')
+            ]),
+            val=gnmi_pb2.TypedValue(int_val=1500)
+        ),
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth0'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='enabled')
+            ]),
+            val=gnmi_pb2.TypedValue(bool_val=True)
+        )
+    ]
+)
+
+response_interface_status = gnmi_pb2.Notification(
+    timestamp=(int(time.time())) * 1000000000,
+    update=[
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth0'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='oper-status')
+            ]),
+            val=gnmi_pb2.TypedValue(string_val='UP')
+        ),
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'eth1'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='oper-status')
+            ]),
+            val=gnmi_pb2.TypedValue(string_val='DOWN')
+        ),
+        gnmi_pb2.Update(
+            path=gnmi_pb2.Path(elem=[
+                gnmi_pb2.PathElem(name='interfaces'),
+                gnmi_pb2.PathElem(
+                    name='interface', key={'name': 'mgmt'}),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='oper-status')
+            ]),
+            val=gnmi_pb2.TypedValue(string_val='UP')
+        )
+    ]
+)
 
 
 @mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
@@ -65,12 +178,13 @@ class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
             gnmi_pb2.Notification(
                 timestamp=(int(time.time()) + 10) * 1000000000)  # 10 second later
         ] * got
-        with self.assertRaisesRegex(AssertionError, f"Expected {want} notifications, got {got}"):
+        with self.assertRaisesRegex(
+                AssertionError,
+                f"Expected {want} notifications, got {got}"):
             self.subscribeOnce()
 
     def check_bad_update_path(self, mock_gNMISubsOnce):
         """Test subscribeOnce when the path of an update is not as subscribed."""
-
         self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
         mock_gNMISubsOnce.return_value = [
             gnmi_pb2.Notification(
@@ -93,15 +207,12 @@ class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
                                 gnmi_pb2.PathElem(name='system'),
                                 gnmi_pb2.PathElem(name='state'),
                                 gnmi_pb2.PathElem(name='hostname')],
-
                         ),
                         val=gnmi_pb2.TypedValue(string_val='localhost')
 
                     )
                 ])
-
         ]
-
         with self.assertRaisesRegex(
                 AssertionError,
                 "False is not true : "
@@ -132,119 +243,6 @@ class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
 class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
     """Test for CountUpdatesCheckType class."""
 
-    def setUp(self):
-
-        self.response_hostname = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='system'),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='hostname')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='localhost')
-                )
-            ]
-        )
-
-        self.response_interface_status = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='UP')
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth1'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='DOWN')
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'mgmt'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='UP')
-                )
-            ]
-        )
-        self.response_interface_eth0_enabled = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='config'),
-                        gnmi_pb2.PathElem(name='enabled')
-                    ]),
-                    val=gnmi_pb2.TypedValue(bool_val=True)
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='enabled')
-                    ]),
-                    val=gnmi_pb2.TypedValue(bool_val=False)
-                )
-            ]
-        )
-
-        self.response_interface_eth0_state = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='UP')
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='mtu')
-                    ]),
-                    val=gnmi_pb2.TypedValue(int_val=1500)
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='enabled')
-                    ]),
-                    val=gnmi_pb2.TypedValue(bool_val=True)
-                )
-            ]
-        )
-
     def check_bad_args(self, mock_gNMISubsOnce):
         """Test that CountUpdatesCheckType raises an error for missing arguments."""
         with self.assertRaises(AssertionError):
@@ -270,26 +268,23 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
         self.updates_count = 3
         self.values_type = 'string_val'
         self.xpaths = ['/system/state/hostname']
-        mock_gNMISubsOnce.return_value = [
-            self.response_hostname
-        ]
+        mock_gNMISubsOnce.return_value = [response_hostname]
         with self.assertRaisesRegex(AssertionError, "1 != 3 : Expected 3 Updates, got: 1"):
             self.testSubscribeOnce()
 
         self.updates_count = 1
         self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
-        mock_gNMISubsOnce.return_value = [
-            self.response_interface_status
-        ]
+        mock_gNMISubsOnce.return_value = [response_interface_status]
         with self.assertRaisesRegex(AssertionError, "3 != 1 : Expected 1 Updates, got: 3"):
             self.testSubscribeOnce()
 
     def check_bad_type(self, mock_gNMISubsOnce):
         """Test CountUpdatesCheckType when the value type is not as expected."""
-
         self.values_type = 'string_val'
         self.updates_count = 3
         self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
+        self.response_interface_status = copy.deepcopy(
+            response_interface_status)
         self.response_interface_status.update[1].val.ClearField('string_val')
         self.response_interface_status.update[1].val.int_val = 1
 
@@ -305,13 +300,10 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
 
     def check_container(self, mock_gNMISubsOnce):
         """Test CountUpdatesCheckType when the path of an update is a container."""
-
         self.xpaths = ['/interfaces/interface[name=eth0]/state']
         self.values_type = 'string_val'
         self.updates_count = 3
-        mock_gNMISubsOnce.return_value = [
-            self.response_interface_eth0_state
-        ]
+        mock_gNMISubsOnce.return_value = [response_interface_eth0_state]
         with self.assertRaisesRegex(
                 AssertionError,
                 re.compile(r"False is not true : "
@@ -327,8 +319,8 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
         self.updates_count = 4
         self.values_type = 'string_val'
         mock_gNMISubsOnce.return_value = [
-            self.response_interface_status,
-            self.response_hostname
+            response_interface_status,
+            response_hostname
         ]
         self.testSubscribeOnce()
 
@@ -336,7 +328,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
         self.updates_count = 2
         self.values_type = 'bool_val'
         mock_gNMISubsOnce.return_value = [
-            self.response_interface_eth0_enabled
+            response_interface_eth0_enabled
         ]
         self.testSubscribeOnce()
 
@@ -344,119 +336,6 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
 @mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
 class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
     """Test for CountUpdatePaths class."""
-
-    def setUp(self):
-
-        self.response_hostname = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='system'),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='hostname')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='localhost')
-                )
-            ]
-        )
-
-        self.response_interface_status = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='UP')
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth1'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='DOWN')
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'mgmt'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='UP')
-                )
-            ]
-        )
-        self.response_interface_eth0_enabled = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='config'),
-                        gnmi_pb2.PathElem(name='enabled')
-                    ]),
-                    val=gnmi_pb2.TypedValue(bool_val=True)
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='enabled')
-                    ]),
-                    val=gnmi_pb2.TypedValue(bool_val=False)
-                )
-            ]
-        )
-
-        self.response_interface_eth0_state = gnmi_pb2.Notification(
-            timestamp=(int(time.time())) * 1000000000,
-            update=[
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='oper-status')
-                    ]),
-                    val=gnmi_pb2.TypedValue(string_val='UP')
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='mtu')
-                    ]),
-                    val=gnmi_pb2.TypedValue(int_val=1500)
-                ),
-                gnmi_pb2.Update(
-                    path=gnmi_pb2.Path(elem=[
-                        gnmi_pb2.PathElem(name='interfaces'),
-                        gnmi_pb2.PathElem(
-                            name='interface', key={'name': 'eth0'}),
-                        gnmi_pb2.PathElem(name='state'),
-                        gnmi_pb2.PathElem(name='enabled')
-                    ]),
-                    val=gnmi_pb2.TypedValue(bool_val=True)
-                )
-            ]
-        )
 
     def check_bad_args(self, mock_gNMISubsOnce):
         """Test that CountUpdatePaths raises an error for missing argument."""
@@ -478,9 +357,7 @@ class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
         """Test CountUpdatePaths when the updates are not as expected."""
         self.update_paths_count = 4
         self.xpaths = ['/interfaces/interface[name=*]/state/oper-status']
-        mock_gNMISubsOnce.return_value = [
-            self.response_interface_status
-        ]
+        mock_gNMISubsOnce.return_value = [response_interface_status]
         with self.assertRaisesRegex(
             AssertionError,
             re.compile(
@@ -490,8 +367,8 @@ class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
         self.update_paths_count = 1
         self.xpaths = ['/system/state']
         mock_gNMISubsOnce.return_value = [
-            self.response_hostname,
-            self.response_hostname,
+            response_hostname,
+            response_hostname,
         ]
         self.testSubscribeOnce()
 
@@ -502,11 +379,77 @@ class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
             '/interfaces/interface[name=*]/state/oper-status']
         self.update_paths_count = 5
         mock_gNMISubsOnce.return_value = [
-            self.response_interface_status,
-            self.response_interface_eth0_enabled,
-            self.response_interface_status,
+            response_interface_status,
+            response_interface_eth0_enabled,
+            response_interface_status,
         ]
         self.testSubscribeOnce()
+
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
+class TestCheckLeafsFromModel(telemetry_once.CheckLeafsFromModel):
+    """Test for CheckLeafsFromModel class."""
+
+    def check_bad_args(self, mock_gNMISubsOnce):
+        """Test that CheckLeafsFromModel raises an error for missing argument."""
+        with self.assertRaises(AssertionError):
+            self.testSubscribeOnce()
+
+        self.xpaths = ['/valid/path']
+        with self.assertRaises(AssertionError):
+            self.testSubscribeOnce()
+
+        self.model = "interfaces.openconfig_interfaces"
+        self.xpaths = None
+        with self.assertRaises(AssertionError):
+            self.testSubscribeOnce()
+
+        mock_gNMISubsOnce.assert_not_called()
+
+    def check_ok(self, mock_gNMISubsOnce):
+        """Test that CheckLeafsFromModel works as expected."""
+        self.xpaths = ['/interfaces/interface[name=eth0]/state']
+        self.model = "interfaces.openconfig_interfaces"
+        mock_gNMISubsOnce.return_value = [response_interface_eth0_state]
+        self.testSubscribeOnce()
+
+        self.xpaths = ['/interfaces/interface[name=*]/state']
+        self.model = "interfaces.openconfig_interfaces"
+        mock_gNMISubsOnce.return_value = [response_interface_status]
+        self.testSubscribeOnce()
+
+    def check_missing_paths(self, mock_gNMISubsOnce):
+        """Test that CheckLeafsFromModel works as expected with missing paths from model."""
+        self.check_missing_model_paths = True
+        self.xpaths = ['/interfaces/interface[name=eth0]/state']
+        self.model = "interfaces.openconfig_interfaces"
+        mock_gNMISubsOnce.return_value = [response_interface_eth0_state]
+        with self.assertRaisesRegex(
+                AssertionError,
+                "Missing update path for OC model interfaces.openconfig_interfaces"):
+            self.testSubscribeOnce()
+
+    def check_bad_model(self, mock_gNMISubsOnce):
+        """Test that CheckLeafsFromModel raises an error for bad model."""
+        self.xpaths = ['/interfaces/interface[name=eth0]/state']
+        self.model = "bad_model"
+        with self.assertRaisesRegex(
+            AssertionError,
+                "bad_model is not module.class"):
+            self.testSubscribeOnce()
+
+        self.model = "system.openconfig_system"
+        with self.assertRaisesRegex(
+            AssertionError,
+                "'openconfig_system' object has no attribute 'interfaces'"):
+            self.testSubscribeOnce()
+
+        self.xpaths = ['/system/state/hostname']
+        mock_gNMISubsOnce.return_value = [response_hostname]
+        with self.assertRaisesRegex(
+            AssertionError,
+                "system.openconfig_system:/system/state/hostname is not a valid container class"):
+            self.testSubscribeOnce()
 
 
 if __name__ == '__main__':

--- a/oc_config_validate/py_tests/testcases/test_telemetry_once.py
+++ b/oc_config_validate/py_tests/testcases/test_telemetry_once.py
@@ -1,0 +1,332 @@
+"""Copyright 2023 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+                https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+import time
+import unittest
+from unittest import mock
+import re
+
+from parameterized import parameterized
+
+from oc_config_validate.gnmi import gnmi_pb2  # type: ignore
+from oc_config_validate.testcases import telemetry_once
+
+# Use 'check' instead of 'test', not to mix with test methods in oc_config_validate.testcases
+unittest.TestLoader.testMethodPrefix = 'check'
+mock.patch.TEST_PREFIX = 'check'
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
+class TestSubsOnceTestCase(telemetry_once.SubsOnceTestCase):
+    """Test for SubsOnceTestCase class."""
+
+    def setUp(self):
+        self.xpaths = ['/valid/path']
+
+    def check_bad_path(self, mock_gNMISubsOnce):
+        """Test that subscribeOnce raises an error for bad path."""
+        self.xpaths = ['/network-instances/network-instance[default]']
+        with self.assertRaises(AssertionError):
+            self.subscribeOnce()
+        mock_gNMISubsOnce.assert_not_called()
+
+    @parameterized.expand([
+        ("none", None),
+        ("empty", [])
+    ])
+    def check_no_responses(self, mock_gNMISubsOnce, name, response):
+        """Test that subscribeOnce raises an error when no responses are received."""
+        mock_gNMISubsOnce.return_value = response
+        with self.assertRaisesRegex(AssertionError, "No gNMI Subscribe response"):
+            self.subscribeOnce()
+        self.assertTrue(mock_gNMISubsOnce.called)
+
+    @parameterized.expand([
+        ("want_1_got_3", 1, 3),
+        ("want_3_got_1", 3, 1)
+    ])
+    def check_bad_notifications(self, mock_gNMISubsOnce, name, want, got):
+        """Test that subscribeOnce raises an error when the notifications are not as expected."""
+        self.notifications_count = want
+        mock_gNMISubsOnce.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=(int(time.time()) + 10) * 1000000000)  # 10 second later
+        ] * got
+        with self.assertRaisesRegex(AssertionError, f"Expected {want} notifications, got {got}"):
+            self.subscribeOnce()
+
+    def check_ok_nothing_checked(self, mock_gNMISubsOnce):
+        """Test that subscribeOnce does NOT check Notifications nor delays if not told so."""
+        mock_gNMISubsOnce.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=(int(time.time()) + 30) * 1000000000),
+            gnmi_pb2.Notification(
+                timestamp=(int(time.time()) + 35) * 1000000000)
+        ]
+        self.subscribeOnce()
+
+        self.max_delay_secs = 3
+        with self.assertRaisesRegex(AssertionError, "Timestamp diff too long: 30 secs"):
+            self.subscribeOnce()
+
+        self.max_delay_secs = None
+        self.notifications_count = 1
+        with self.assertRaisesRegex(AssertionError, "Expected 1 notifications, got 2"):
+            self.subscribeOnce()
+
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
+class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
+    """Test for CountUpdatesCheckType class."""
+
+    def setUp(self):
+
+        self.response_hostname = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='system'),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='hostname')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='localhost')
+                )
+            ]
+        )
+
+        self.response_interface_status = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='UP')
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth1'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='DOWN')
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'mgmt'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='UP')
+                )
+            ]
+        )
+        self.response_interface_eth0_enabled = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='config'),
+                        gnmi_pb2.PathElem(name='enabled')
+                    ]),
+                    val=gnmi_pb2.TypedValue(bool_val=True)
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='enabled')
+                    ]),
+                    val=gnmi_pb2.TypedValue(bool_val=False)
+                )
+            ]
+        )
+
+        self.response_interface_eth0_state = gnmi_pb2.Notification(
+            timestamp=(int(time.time())) * 1000000000,
+            update=[
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='oper-status')
+                    ]),
+                    val=gnmi_pb2.TypedValue(string_val='UP')
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='mtu')
+                    ]),
+                    val=gnmi_pb2.TypedValue(int_val=1500)
+                ),
+                gnmi_pb2.Update(
+                    path=gnmi_pb2.Path(elem=[
+                        gnmi_pb2.PathElem(name='interaces'),
+                        gnmi_pb2.PathElem(
+                            name='interface', key={'name': 'eth0'}),
+                        gnmi_pb2.PathElem(name='state'),
+                        gnmi_pb2.PathElem(name='enabled')
+                    ]),
+                    val=gnmi_pb2.TypedValue(bool_val=True)
+                )
+            ]
+        )
+
+    def check_bad_args(self, mock_gNMISubsOnce):
+        """Test that CountUpdatesCheckType raises an error for missing arguments."""
+        self.xpaths = []
+
+        with self.assertRaises(AssertionError):
+            self.test100()
+
+        self.xpaths = ['/valid/path']
+        with self.assertRaises(AssertionError):
+            self.test100()
+
+        self.values_type = 'string_val'
+        with self.assertRaises(AssertionError):
+            self.test100()
+        
+        self.values_type = None
+        self.updates_count = 1
+        with self.assertRaises(AssertionError):
+            self.test100()
+
+        mock_gNMISubsOnce.assert_not_called()
+
+    def check_bad_count_updates(self, mock_gNMISubsOnce):
+        """Test CountUpdatesCheckType when the updates are not as expected."""
+        self.updates_count = 3
+        self.values_type = 'string_val'
+        self.xpaths = ['/system/state/hostname']
+        mock_gNMISubsOnce.return_value = [
+            self.response_hostname
+        ]
+        with self.assertRaisesRegex(AssertionError, "1 != 3 : Expected 3 Updates, got: 1"):
+            self.test100()
+
+        self.updates_count = 1
+        self.xpaths = ['/interaces/interface[name=*]/state/oper-status']
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_status
+        ]
+        with self.assertRaisesRegex(AssertionError, "3 != 1 : Expected 1 Updates, got: 3"):
+            self.test100()
+
+    def check_bad_type(self, mock_gNMISubsOnce):
+        """Test CountUpdatesCheckType when the value type is not as expected."""
+
+        self.values_type = 'string_val'
+        self.updates_count = 3
+        self.xpaths = ['/interaces/interface[name=*]/state/oper-status']
+        self.response_interface_status.update[1].val.ClearField('string_val')
+        self.response_interface_status.update[1].val.int_val = 1
+        
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_status
+        ]
+        with self.assertRaisesRegex(
+                AssertionError,
+                re.compile(r"False is not true : "
+                           r"Value of Update /interaces/interface\[name=eth1\]/state/oper-status "
+                           r"is not of type string_val: .*")):
+            self.test100()
+
+    def check_bad_update_path(self, mock_gNMISubsOnce):
+        """Test CountUpdatesCheckType when the path of an update is not as expected."""
+
+        self.xpaths = ['/interaces/interface[name=*]/state/oper-status']
+        self.values_type = 'string_val'
+        self.updates_count = 4
+        self.response_interface_status.update.append(
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path( 
+                    elem=[
+                gnmi_pb2.PathElem(name='system'),
+                gnmi_pb2.PathElem(name='state'),
+                gnmi_pb2.PathElem(name='hostname')],
+
+                ),
+                val=gnmi_pb2.TypedValue(string_val='localhost')
+            
+            ))
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_status
+        ]
+        with self.assertRaisesRegex(
+                AssertionError,
+                "False is not true : Unexpected update path /system/state/hostname for subscription"):
+            self.test100()
+
+    def check_container(self, mock_gNMISubsOnce):
+        """Test CountUpdatesCheckType when the path of an update is a container."""
+
+        self.xpaths = ['/interaces/interface[name=eth0]/state']
+        self.values_type = 'string_val'
+        self.updates_count = 3
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_eth0_state
+        ]
+        with self.assertRaisesRegex(
+                AssertionError,
+                re.compile(r"False is not true : "
+                           r"Value of Update /interaces/interface\[name=eth0\]/state/mtu "
+                           r"is not of type string_val: .*")):
+            self.test100()
+
+    def check_ok(self, mock_gNMISubsOnce):
+        """Test that CountUpdatesCheckType works as expected."""
+        self.xpaths = [
+            '/system/state/hostname',
+            '/interaces/interface[name=*]/state/oper-status']
+        self.updates_count = 4
+        self.values_type = 'string_val'
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_status,
+            self.response_hostname
+        ]
+        self.test100()
+
+        self.xpaths = ['/interaces/interface[name=eth0]/*/enabled']
+        self.updates_count = 2
+        self.values_type = 'bool_val'
+        mock_gNMISubsOnce.return_value = [
+            self.response_interface_eth0_enabled
+        ]
+        self.test100()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/oc_config_validate/py_tests/testcases/test_telemetry_once.py
+++ b/oc_config_validate/py_tests/testcases/test_telemetry_once.py
@@ -340,6 +340,7 @@ class TestCountUpdatesCheckType(telemetry_once.CountUpdatesCheckType):
         ]
         self.testSubscribeOnce()
 
+
 @mock.patch('oc_config_validate.testbase.TestCase.gNMISubsOnce')
 class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
     """Test for CountUpdatePaths class."""
@@ -481,9 +482,9 @@ class TestCountUpdatePaths(telemetry_once.CountUpdatePaths):
             self.response_interface_status
         ]
         with self.assertRaisesRegex(
-            AssertionError, 
+            AssertionError,
             re.compile(
-            r"3 != 4 : Expected 4 Update paths, got: .*")            ):
+                r"3 != 4 : Expected 4 Update paths, got: .*")):
             self.testSubscribeOnce()
 
         self.update_paths_count = 1

--- a/oc_config_validate/py_tests/testcases/test_telemetry_sample.py
+++ b/oc_config_validate/py_tests/testcases/test_telemetry_sample.py
@@ -29,6 +29,73 @@ unittest.TestLoader.testMethodPrefix = 'check'
 mock.patch.TEST_PREFIX = 'check'
 
 
+updates_interface_status = [
+    gnmi_pb2.Update(
+        path=gnmi_pb2.Path(elem=[
+            gnmi_pb2.PathElem(name='interfaces'),
+            gnmi_pb2.PathElem(
+                name='interface', key={'name': 'eth0'}),
+            gnmi_pb2.PathElem(name='state'),
+            gnmi_pb2.PathElem(name='oper-status')
+        ]),
+        val=gnmi_pb2.TypedValue(string_val='UP')
+    ),
+    gnmi_pb2.Update(
+        path=gnmi_pb2.Path(elem=[
+            gnmi_pb2.PathElem(name='interfaces'),
+            gnmi_pb2.PathElem(
+                name='interface', key={'name': 'eth1'}),
+            gnmi_pb2.PathElem(name='state'),
+            gnmi_pb2.PathElem(name='oper-status')
+        ]),
+        val=gnmi_pb2.TypedValue(string_val='DOWN')
+    ),
+    gnmi_pb2.Update(
+        path=gnmi_pb2.Path(elem=[
+            gnmi_pb2.PathElem(name='interfaces'),
+            gnmi_pb2.PathElem(
+                name='interface', key={'name': 'mgmt'}),
+            gnmi_pb2.PathElem(name='state'),
+            gnmi_pb2.PathElem(name='oper-status')
+        ]),
+        val=gnmi_pb2.TypedValue(string_val='UP')
+    )
+]
+
+updates_interface_eth0_state = [
+    gnmi_pb2.Update(
+        path=gnmi_pb2.Path(elem=[
+            gnmi_pb2.PathElem(name='interfaces'),
+            gnmi_pb2.PathElem(
+                name='interface', key={'name': 'eth0'}),
+            gnmi_pb2.PathElem(name='state'),
+            gnmi_pb2.PathElem(name='oper-status')
+        ]),
+        val=gnmi_pb2.TypedValue(string_val='UP')
+    ),
+    gnmi_pb2.Update(
+        path=gnmi_pb2.Path(elem=[
+            gnmi_pb2.PathElem(name='interfaces'),
+            gnmi_pb2.PathElem(
+                name='interface', key={'name': 'eth0'}),
+            gnmi_pb2.PathElem(name='state'),
+            gnmi_pb2.PathElem(name='mtu')
+        ]),
+        val=gnmi_pb2.TypedValue(int_val=1500)
+    ),
+    gnmi_pb2.Update(
+        path=gnmi_pb2.Path(elem=[
+            gnmi_pb2.PathElem(name='interfaces'),
+            gnmi_pb2.PathElem(
+                name='interface', key={'name': 'eth0'}),
+            gnmi_pb2.PathElem(name='state'),
+            gnmi_pb2.PathElem(name='enabled')
+        ]),
+        val=gnmi_pb2.TypedValue(bool_val=True)
+    )
+]
+
+
 @mock.patch('oc_config_validate.testbase.TestCase.gNMISubsStreamSample')
 class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
     """Test for SubsSampleTestCase class."""
@@ -37,40 +104,6 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
         self.xpath = '/interfaces/interface[name=*]/state/oper-status'
         self.sample_interval = 10
         self.sample_timeout = 35
-
-        # In Setup, so every test has a known set of updates to work with.
-        self.updates_interface_status = [
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path(elem=[
-                    gnmi_pb2.PathElem(name='interfaces'),
-                    gnmi_pb2.PathElem(
-                        name='interface', key={'name': 'eth0'}),
-                    gnmi_pb2.PathElem(name='state'),
-                    gnmi_pb2.PathElem(name='oper-status')
-                ]),
-                val=gnmi_pb2.TypedValue(string_val='UP')
-            ),
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path(elem=[
-                    gnmi_pb2.PathElem(name='interfaces'),
-                    gnmi_pb2.PathElem(
-                        name='interface', key={'name': 'eth1'}),
-                    gnmi_pb2.PathElem(name='state'),
-                    gnmi_pb2.PathElem(name='oper-status')
-                ]),
-                val=gnmi_pb2.TypedValue(string_val='DOWN')
-            ),
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path(elem=[
-                    gnmi_pb2.PathElem(name='interfaces'),
-                    gnmi_pb2.PathElem(
-                        name='interface', key={'name': 'mgmt'}),
-                    gnmi_pb2.PathElem(name='state'),
-                    gnmi_pb2.PathElem(name='oper-status')
-                ]),
-                val=gnmi_pb2.TypedValue(string_val='UP')
-            )
-        ]
 
     def check_bad_args(self, mock_gNMISubsStreamSample):
         """Test that subscribeSample raises an error for missing arguments."""
@@ -114,21 +147,20 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
 
     def check_bad_updates(self, mock_gNMISubsStreamSample):
         """Test that subscribeSample raises an error when missing updates for a path."""
-
         self.max_timestamp_drift_secs = 10
         now = int(time.time())
         mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 11) * 1000000000,
-                update=self.updates_interface_status[1:]
+                update=updates_interface_status[1:]
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 22) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             )
         ]
         with self.assertRaisesRegex(
@@ -141,23 +173,23 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
         mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 8) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 16) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 24) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 32) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             )
         ]
         with self.assertRaisesRegex(
@@ -173,19 +205,19 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
         mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 10) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 22) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 30) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             )
         ]
         with self.assertRaisesRegex(
@@ -202,20 +234,19 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
 
     def check_bad_update_path(self, mock_gNMISubsStreamSample):
         """Test subscribeOnce when the path of an update is not as subscribed."""
-
         now = int(time.time())
         mock_gNMISubsStreamSample.return_value = mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 11) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 22) * 1000000000,
-                update=self.updates_interface_status + [
+                update=updates_interface_status + [
                     gnmi_pb2.Update(
                         path=gnmi_pb2.Path(elem=[
                             gnmi_pb2.PathElem(name='system'),
@@ -228,10 +259,9 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 31) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
         ]
-
         with self.assertRaisesRegex(
                 AssertionError,
                 "False is not true : "
@@ -240,24 +270,23 @@ class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
 
     def check_ok(self, mock_gNMISubsStreamSample):
         """Test that subscribeSample works as expected."""
-
         now = int(time.time())
         mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 11) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 20) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 29) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             )
         ]
         self.subscribeSample()
@@ -272,43 +301,8 @@ class TestCountUpdatePaths(telemetry_sample.CountUpdatePaths):
         self.sample_timeout = 30
         self.xpath = '/interfaces/interface[name=*]/state/oper-status'
 
-        # In Setup, so every test has a known set of updates to work with.
-        self.updates_interface_status = [
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path(elem=[
-                    gnmi_pb2.PathElem(name='interfaces'),
-                    gnmi_pb2.PathElem(
-                        name='interface', key={'name': 'eth0'}),
-                    gnmi_pb2.PathElem(name='state'),
-                    gnmi_pb2.PathElem(name='oper-status')
-                ]),
-                val=gnmi_pb2.TypedValue(string_val='UP')
-            ),
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path(elem=[
-                    gnmi_pb2.PathElem(name='interfaces'),
-                    gnmi_pb2.PathElem(
-                        name='interface', key={'name': 'eth1'}),
-                    gnmi_pb2.PathElem(name='state'),
-                    gnmi_pb2.PathElem(name='oper-status')
-                ]),
-                val=gnmi_pb2.TypedValue(string_val='DOWN')
-            ),
-            gnmi_pb2.Update(
-                path=gnmi_pb2.Path(elem=[
-                    gnmi_pb2.PathElem(name='interfaces'),
-                    gnmi_pb2.PathElem(
-                        name='interface', key={'name': 'mgmt'}),
-                    gnmi_pb2.PathElem(name='state'),
-                    gnmi_pb2.PathElem(name='oper-status')
-                ]),
-                val=gnmi_pb2.TypedValue(string_val='UP')
-            )
-        ]
-
     def check_bad_args(self, mock_gNMISubsStreamSample):
         """Test that CountUpdatePaths raises an error for missing arguments."""
-
         with self.assertRaises(AssertionError):
             self.testSubscribeSample()
 
@@ -317,25 +311,23 @@ class TestCountUpdatePaths(telemetry_sample.CountUpdatePaths):
     def check_bad_count_updates(self, mock_gNMISubsStreamSample):
         """Test CountUpdatePaths when the update paths are not as expected."""
         self.update_paths_count = 3
-
         now = int(time.time())
-
         mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status[2:]
+                update=updates_interface_status[2:]
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 10) * 1000000000,
-                update=self.updates_interface_status[2:]
+                update=updates_interface_status[2:]
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 20) * 1000000000,
-                update=self.updates_interface_status[2:]
+                update=updates_interface_status[2:]
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 30) * 1000000000,
-                update=self.updates_interface_status[2:]
+                update=updates_interface_status[2:]
             )
         ]
         with self.assertRaisesRegex(
@@ -349,27 +341,160 @@ class TestCountUpdatePaths(telemetry_sample.CountUpdatePaths):
         """Test that CountUpdatePaths works as expected."""
         self.update_paths_count = 3
         now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=updates_interface_status
+            )
+        ]
+        self.testSubscribeSample()
+
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsStreamSample')
+class TestCheckLeafsFromModel(telemetry_sample.CheckLeafsFromModel):
+    """Test for CheckLeafsFromModel class."""
+
+    def setUp(self):
+        self.sample_interval = 10
+        self.sample_timeout = 30
+        self.xpath = '/interfaces/interface[name=*]/state'
+        self.model = "interfaces.openconfig_interfaces"
+
+    def check_bad_args(self, mock_gNMISubsStreamSample):
+        """Test that CheckLeafsFromModel raises an error for missing argument."""
+        self.model = None
+        with self.assertRaises(AssertionError):
+            self.testSubscribeSample()
+
+        self.model = "interfaces.openconfig_interfaces"
+        self.xpath = None
+        with self.assertRaises(AssertionError):
+            self.testSubscribeSample()
+
+        mock_gNMISubsStreamSample.assert_not_called()
+
+    def check_ok(self, mock_gNMISubsStreamSample):
+        """Test that CheckLeafsFromModel works as expected."""
+        now = int(time.time())
 
         mock_gNMISubsStreamSample.return_value = [
             gnmi_pb2.Notification(
                 timestamp=now * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 11) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 20) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
             ),
             gnmi_pb2.Notification(
                 timestamp=(now + 30) * 1000000000,
-                update=self.updates_interface_status
+                update=updates_interface_status
+            )
+        ]
+        self.testSubscribeSample()
+
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=updates_interface_eth0_state
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=updates_interface_eth0_state
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=updates_interface_eth0_state
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=updates_interface_eth0_state
+            )
+        ]
+        self.testSubscribeSample()
+
+    def check_missing_paths(self, mock_gNMISubsStreamSample):
+        """Test that CheckLeafsFromModel works as expected with missing paths from model."""
+        self.check_missing_model_paths = True
+        now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=updates_interface_status
+            )
+        ]
+        with self.assertRaisesRegex(
+            AssertionError,
+                "Missing update path for OC model interfaces.openconfig_interfaces"):
+            self.testSubscribeSample()
+
+    def check_bad_model(self, mock_gNMISubsStreamSample):
+        """Test that CheckLeafsFromModel raises an error for bad model."""
+        now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=updates_interface_status
             )
         ]
 
-        self.testSubscribeSample()
+        self.xpath = '/interfaces/interface[name=*]/state/oper-status'
+        with self.assertRaisesRegex(
+                AssertionError,
+                "/state/oper-status is not a valid container class"):
+            self.testSubscribeSample()
+
+        self.model = "bad_model"
+        with self.assertRaisesRegex(
+                AssertionError,
+                "bad_model is not module.class"):
+            self.testSubscribeSample()
+
+        self.model = "system.openconfig_system"
+        with self.assertRaisesRegex(
+                AssertionError,
+                "'openconfig_system' object has no attribute 'interfaces'"):
+            self.testSubscribeSample()
 
 
 if __name__ == '__main__':

--- a/oc_config_validate/py_tests/testcases/test_telemetry_sample.py
+++ b/oc_config_validate/py_tests/testcases/test_telemetry_sample.py
@@ -1,0 +1,376 @@
+"""Copyright 2023 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+                https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+"""
+
+import re
+import time
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from oc_config_validate.gnmi import gnmi_pb2  # type: ignore
+from oc_config_validate.testcases import telemetry_sample
+
+# Use 'check' instead of 'test', not to mix with test methods in oc_config_validate.testcases
+unittest.TestLoader.testMethodPrefix = 'check'
+mock.patch.TEST_PREFIX = 'check'
+
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsStreamSample')
+class TestSubsSampleTestCase(telemetry_sample.SubsSampleTestCase):
+    """Test for SubsSampleTestCase class."""
+
+    def setUp(self):
+        self.xpath = '/interfaces/interface[name=*]/state/oper-status'
+        self.sample_interval = 10
+        self.sample_timeout = 35
+
+        # In Setup, so every test has a known set of updates to work with.
+        self.updates_interface_status = [
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path(elem=[
+                    gnmi_pb2.PathElem(name='interfaces'),
+                    gnmi_pb2.PathElem(
+                        name='interface', key={'name': 'eth0'}),
+                    gnmi_pb2.PathElem(name='state'),
+                    gnmi_pb2.PathElem(name='oper-status')
+                ]),
+                val=gnmi_pb2.TypedValue(string_val='UP')
+            ),
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path(elem=[
+                    gnmi_pb2.PathElem(name='interfaces'),
+                    gnmi_pb2.PathElem(
+                        name='interface', key={'name': 'eth1'}),
+                    gnmi_pb2.PathElem(name='state'),
+                    gnmi_pb2.PathElem(name='oper-status')
+                ]),
+                val=gnmi_pb2.TypedValue(string_val='DOWN')
+            ),
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path(elem=[
+                    gnmi_pb2.PathElem(name='interfaces'),
+                    gnmi_pb2.PathElem(
+                        name='interface', key={'name': 'mgmt'}),
+                    gnmi_pb2.PathElem(name='state'),
+                    gnmi_pb2.PathElem(name='oper-status')
+                ]),
+                val=gnmi_pb2.TypedValue(string_val='UP')
+            )
+        ]
+
+    def check_bad_args(self, mock_gNMISubsStreamSample):
+        """Test that subscribeSample raises an error for missing arguments."""
+        self.xpath = None
+        self.sample_interval = None
+        self.sample_timeout = None
+
+        with self.assertRaises(AssertionError):
+            self.subscribeSample()
+
+        self.xpath = '/valid/path'
+        with self.assertRaises(AssertionError):
+            self.subscribeSample()
+
+        self.sample_interval = 10
+        with self.assertRaises(AssertionError):
+            self.subscribeSample()
+
+        mock_gNMISubsStreamSample.assert_not_called()
+
+        self.sample_timeout = 30
+        self.subscribeSample()
+
+    def check_bad_path(self, mock_gNMISubsStreamSample):
+        """Test that subscribeSample raises an error for bad path."""
+        self.xpath = '/network-instances/network-instance[default]'
+        with self.assertRaises(AssertionError):
+            self.subscribeSample()
+        mock_gNMISubsStreamSample.assert_not_called()
+
+    @parameterized.expand([
+        ("none", None),
+        ("empty", [])
+    ])
+    def check_no_responses(self, mock_gNMISubsStreamSample, name, response):
+        """Test that subscribeSample raises an error when no responses are received."""
+        mock_gNMISubsStreamSample.return_value = response
+        with self.assertRaisesRegex(AssertionError, "No gNMI Subscribe response"):
+            self.subscribeSample()
+        self.assertTrue(mock_gNMISubsStreamSample.called)
+
+    def check_bad_updates(self, mock_gNMISubsStreamSample):
+        """Test that subscribeSample raises an error when missing updates for a path."""
+
+        self.max_timestamp_drift_secs = 10
+        now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=self.updates_interface_status[1:]
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 22) * 1000000000,
+                update=self.updates_interface_status
+            )
+        ]
+        with self.assertRaisesRegex(
+            AssertionError,
+            re.compile(
+                r"2 != 4 : 2 Updates for /interfaces/interface\[name=eth0\]/state/oper-status, "
+                r"wanted 4")):
+            self.subscribeSample()
+
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 8) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 16) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 24) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 32) * 1000000000,
+                update=self.updates_interface_status
+            )
+        ]
+        with self.assertRaisesRegex(
+            AssertionError,
+            re.compile(
+                r"5 != 4 : 5 Updates for /interfaces/interface\[name=eth0\]/state/oper-status, "
+                r"wanted 4")):
+            self.subscribeSample()
+
+    def check_bad_timestamp(self, mock_gNMISubsStreamSample):
+        """Test that subscribeSample raises an error when timestamps are not within limits."""
+        now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 10) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 22) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=self.updates_interface_status
+            )
+        ]
+        with self.assertRaisesRegex(
+            AssertionError,
+            re.compile(
+                r"False is not true : "
+                r"Subscribe updates for '/interfaces/interface\[name=eth0\]/state/oper-status' "
+                r"received out of sample interval 10 secs, "
+                r"received updates intervals: \[10.0, 12.0\]")):
+            self.subscribeSample()
+
+        self.max_timestamp_drift_secs = 5
+        self.subscribeSample()
+
+    def check_bad_update_path(self, mock_gNMISubsStreamSample):
+        """Test subscribeOnce when the path of an update is not as subscribed."""
+
+        now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 22) * 1000000000,
+                update=self.updates_interface_status + [
+                    gnmi_pb2.Update(
+                        path=gnmi_pb2.Path(elem=[
+                            gnmi_pb2.PathElem(name='system'),
+                            gnmi_pb2.PathElem(name='state'),
+                            gnmi_pb2.PathElem(name='hostname')
+                        ]),
+                        val=gnmi_pb2.TypedValue(string_val='foo')
+                    )
+                ]
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 31) * 1000000000,
+                update=self.updates_interface_status
+            ),
+        ]
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                "False is not true : "
+                "Unexpected update path /system/state/hostname for subscription"):
+            self.subscribeSample()
+
+    def check_ok(self, mock_gNMISubsStreamSample):
+        """Test that subscribeSample works as expected."""
+
+        now = int(time.time())
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 29) * 1000000000,
+                update=self.updates_interface_status
+            )
+        ]
+        self.subscribeSample()
+
+
+@mock.patch('oc_config_validate.testbase.TestCase.gNMISubsStreamSample')
+class TestCountUpdatePaths(telemetry_sample.CountUpdatePaths):
+    """Test for CountUpdatePaths class."""
+
+    def setUp(self):
+        self.sample_interval = 10
+        self.sample_timeout = 30
+        self.xpath = '/interfaces/interface[name=*]/state/oper-status'
+
+        # In Setup, so every test has a known set of updates to work with.
+        self.updates_interface_status = [
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path(elem=[
+                    gnmi_pb2.PathElem(name='interfaces'),
+                    gnmi_pb2.PathElem(
+                        name='interface', key={'name': 'eth0'}),
+                    gnmi_pb2.PathElem(name='state'),
+                    gnmi_pb2.PathElem(name='oper-status')
+                ]),
+                val=gnmi_pb2.TypedValue(string_val='UP')
+            ),
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path(elem=[
+                    gnmi_pb2.PathElem(name='interfaces'),
+                    gnmi_pb2.PathElem(
+                        name='interface', key={'name': 'eth1'}),
+                    gnmi_pb2.PathElem(name='state'),
+                    gnmi_pb2.PathElem(name='oper-status')
+                ]),
+                val=gnmi_pb2.TypedValue(string_val='DOWN')
+            ),
+            gnmi_pb2.Update(
+                path=gnmi_pb2.Path(elem=[
+                    gnmi_pb2.PathElem(name='interfaces'),
+                    gnmi_pb2.PathElem(
+                        name='interface', key={'name': 'mgmt'}),
+                    gnmi_pb2.PathElem(name='state'),
+                    gnmi_pb2.PathElem(name='oper-status')
+                ]),
+                val=gnmi_pb2.TypedValue(string_val='UP')
+            )
+        ]
+
+    def check_bad_args(self, mock_gNMISubsStreamSample):
+        """Test that CountUpdatePaths raises an error for missing arguments."""
+
+        with self.assertRaises(AssertionError):
+            self.testSubscribeSample()
+
+        mock_gNMISubsStreamSample.assert_not_called()
+
+    def check_bad_count_updates(self, mock_gNMISubsStreamSample):
+        """Test CountUpdatePaths when the update paths are not as expected."""
+        self.update_paths_count = 3
+
+        now = int(time.time())
+
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status[2:]
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 10) * 1000000000,
+                update=self.updates_interface_status[2:]
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=self.updates_interface_status[2:]
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=self.updates_interface_status[2:]
+            )
+        ]
+        with self.assertRaisesRegex(
+            AssertionError,
+            re.compile(
+                r"1 != 3 : Expected 3 Update paths, "
+                r"got: \['/interfaces/interface\[name=mgmt\]/state/oper-status'\]")):
+            self.testSubscribeSample()
+
+    def check_ok(self, mock_gNMISubsStreamSample):
+        """Test that CountUpdatePaths works as expected."""
+        self.update_paths_count = 3
+        now = int(time.time())
+
+        mock_gNMISubsStreamSample.return_value = [
+            gnmi_pb2.Notification(
+                timestamp=now * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 11) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 20) * 1000000000,
+                update=self.updates_interface_status
+            ),
+            gnmi_pb2.Notification(
+                timestamp=(now + 30) * 1000000000,
+                update=self.updates_interface_status
+            )
+        ]
+
+        self.testSubscribeSample()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/oc_config_validate/tests/ap_telemetry.yaml
+++ b/oc_config_validate/tests/ap_telemetry.yaml
@@ -23,15 +23,14 @@ tests:
 
 - !TestCase
   name: "Count RADIUS Counters Once"
-  class_name: telemetry_once.CountUpdatesCheckType
+  class_name: telemetry_once.CountUpdatePaths
   args:
     xpaths: ["/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"]
-    values_type: uint_val
-    updates_count: 4
+    update_paths_count: 4
 
 - !TestCase
   name: "Check Radios State Once"
-  class_name: telemetry_once.CheckLeafs
+  class_name: telemetry_once.CheckLeafsFromModel
   args:
     xpaths: ["/access-points/access-point[hostname=*]/radios/radio[id=*][operating-frequency=*]/state"]
     model: "wifi.openconfig_access_points"
@@ -39,21 +38,21 @@ tests:
 
 - !TestCase
   name: "Check MAC SSIDs Once"
-  class_name: telemetry_once.CheckLeafs
+  class_name: telemetry_once.CheckLeafsFromModel
   args:
     xpaths: ["/access-points/access-point[hostname=*]/ssids/ssid[name=*]/bssids/bssid[radio-id=*][bssid=*]/state"]
     model: "wifi.openconfig_access_points"
 
 - !TestCase
   name: "Check RADIUS Counters Once"
-  class_name: telemetry_once.CheckLeafs
+  class_name: telemetry_once.CheckLeafsFromModel
   args:
     xpaths: ["/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"]
     model: "wifi.openconfig_access_points"
 
 - !TestCase
   name: "Count Radios State Sampling"
-  class_name: telemetry_sample.CountUpdates
+  class_name: telemetry_sample.CountUpdatePaths
   args:
     xpath: "/access-points/access-point[hostname=*]/radios/radio[id=*][operating-frequency=FREQ_2GHZ]/state"
     sample_interval: 30
@@ -62,7 +61,7 @@ tests:
 
 - !TestCase
   name: "Check Radios State Sampling"
-  class_name: telemetry_sample.CheckLeafs
+  class_name: telemetry_sample.CheckLeafsFromModel
   args:
     xpath: "/access-points/access-point[hostname=*]/radios/radio[id=*][operating-frequency=FREQ_2GHZ]/state"
     sample_interval: 30
@@ -71,7 +70,7 @@ tests:
 
 - !TestCase
   name: "Count RADIUS Counters Sampling"
-  class_name: telemetry_sample.CountUpdates
+  class_name: telemetry_sample.CountUpdatePaths
   args:
     xpath: "/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"
     sample_interval: 30
@@ -80,7 +79,7 @@ tests:
 
 - !TestCase
   name: "Check RADIUS Counters Sampling"
-  class_name: telemetry_sample.CheckLeafs
+  class_name: telemetry_sample.CheckLeafsFromModel
   args:
     xpath: "/access-points/access-point[hostname=*]/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state/counters"
     sample_interval: 30


### PR DESCRIPTION
 * Added Unit Tests for Telemetry Testclasses
 * Improved documentation for Telemetry Testclasses
 * Added `telemetry_once.CountUpdatePaths`
 * Renamed `*.CheckLeafs` to `*.CheckLeafsFromModel`
 * Updated Demo Files for Telemetry

This PR does imply a change to the Telemetry Testcases, as the mentioned Testclasses `*.CheckLeafs`  were renamed.

This is the ground work to safely start adding more Testclasses for Telemetry