### PR TITLE
gnoi/os: limit OS image size in ReceiveOS to prevent unbounded memory allocation 

### DIFF
--- a/gnoi/os/server.go
+++ b/gnoi/os/server.go
@@ -25,6 +25,9 @@ import (
 )
 
 var receiveChunkSizeAck uint64 = 12000000
+// maxOSImageSize limits the maximum size of an OS image accepted by ReceiveOS
+// to prevent unbounded memory allocation (DoS).
+const maxOSImageSize = 1 << 30 // 1GB
 
 // Server is an OS Management service.
 type Server struct {
@@ -179,6 +182,9 @@ func ReceiveOS(stream pb.OS_InstallServer) (*bytes.Buffer, error) {
 		switch in.Request.(type) {
 		case *pb.InstallRequest_TransferContent:
 			bb.Write(in.GetTransferContent())
+			if bb.Len() > maxOSImageSize {
+				return nil, errors.New("OS image exceeds maximum size")
+			}
 		case *pb.InstallRequest_TransferEnd:
 			log.V(1).Info("InstallRequest:\n", proto.MarshalTextString(in))
 			return bb, nil


### PR DESCRIPTION
Added a maximum OS image size limit to ReceiveOS to prevent unbounded
memory allocation (DoS).

Changes made in gnoi/os/server.go:

1. Added const maxOSImageSize = 1 << 30 (1GB) constant after
   receiveChunkSizeAck variable declaration (lines 29-31).

2. Added a size check after bb.Write() in the TransferContent case
   of ReceiveOS that returns an error when the buffer exceeds
   maxOSImageSize (lines 186-188).

Without this fix, an authenticated client can stream unlimited chunks
to the Install RPC, causing the server to allocate memory until
OOM-killed. The existing installToken semaphore limits concurrency
to 1 but does not prevent a single session from exhausting memory.
